### PR TITLE
Fix IMAX effect to use offset

### DIFF
--- a/solpolpy/constants.py
+++ b/solpolpy/constants.py
@@ -2,5 +2,5 @@
 import astropy.units as u
 
 # offset angles come from https://www.sciencedirect.com/science/article/pii/S0019103515003620?via%3Dihub
-STEREOA_OFFSET_ANGLE = 45.8 * u.degree
-STEREOB_OFFSET_ANGLE = -18 * u.degree
+STEREOA_REFERENCE_ANGLE = 45.8 * u.degree
+STEREOB_REFERENCE_ANGLE = -18 * u.degree

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -57,7 +57,7 @@ def transform(source_system, target_system, use_alpha):
 
 @transform(System.npol, System.mzp, use_alpha=False)
 @u.quantity_input
-def npol_to_mzp(input_collection, offset_angle=0*u.degree, **kwargs):
+def npol_to_mzp(input_collection, reference_angle=0*u.degree, **kwargs):
     """
     Notes
     ------
@@ -70,7 +70,7 @@ def npol_to_mzp(input_collection, offset_angle=0*u.degree, **kwargs):
     data_shape = input_collection[input_keys[0]].data.shape
     data_npol = np.zeros([data_shape[0], data_shape[1], 3, 1])
 
-    conv_matrix = np.array([[(4 * np.cos(phi[i] - mzp_angles[j] - offset_angle) ** 2 - 1) / 3
+    conv_matrix = np.array([[(4 * np.cos(phi[i] - mzp_angles[j] - reference_angle) ** 2 - 1) / 3
                              for j in range(3)] for i in range(3)])
 
     for i, key in enumerate(key for key in input_keys if key != 'alpha'):
@@ -433,7 +433,7 @@ def btbr_to_npol(input_collection, out_angles: u.degree, **kwargs):
 
 @transform(System.mzp, System.npol, use_alpha=False)
 @u.quantity_input
-def mzp_to_npol(input_collection, out_angles: u.degree, offset_angle=0*u.degree, **kwargs):
+def mzp_to_npol(input_collection, out_angles: u.degree, reference_angle=0*u.degree, **kwargs):
     """Notes
     -----
     Equation 45 in DeForest et al. 2022.
@@ -452,7 +452,7 @@ def mzp_to_npol(input_collection, out_angles: u.degree, offset_angle=0*u.degree,
     first_meta = input_collection[in_list[0]].meta
     first_wcs = input_collection[in_list[0]].wcs
     for out_angle in out_angles:
-        value = (1/3) * np.sum([input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - offset_angle)) - 1)
+        value = (1/3) * np.sum([input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
                                      for input_angle, input_cube in input_dict.items()], axis=0)
         out_meta = copy.copy(first_meta)
         out_meta.update(POLAR=out_angle)

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -1,4 +1,7 @@
+import astropy.units as u
 import numpy as np
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
 from ndcube import NDCollection
 
 
@@ -17,3 +20,53 @@ def combine_masks(*args) -> np.ndarray | None:
         return None
     else:
         return np.logical_or.reduce(args)
+
+def calculate_pc_matrix(crota: float, cdelt: (float, float)) -> np.ndarray:
+    """
+    Calculate a PC matrix given CROTA and CDELT.
+
+    Parameters
+    ----------
+    crota : float
+        rotation angle from the WCS
+    cdelt : float
+        pixel size from the WCS
+
+    Returns
+    -------
+    np.ndarray
+        PC matrix
+
+    """
+    return np.array(
+        [
+            [np.cos(crota), -np.sin(crota) * (cdelt[0] / cdelt[1])],
+            [np.sin(crota) * (cdelt[1] / cdelt[0]), np.cos(crota)],
+        ],
+    )
+
+def convert_cd_matrix_to_pc_matrix(wcs):
+    if hasattr(wcs.wcs, 'cd'):
+        cdelt1, cdelt2 = proj_plane_pixel_scales(wcs)
+        crota = np.arccos(wcs.wcs.cd[0, 0]/cdelt1)
+        new_wcs = WCS(naxis=2)
+        new_wcs.wcs.ctype = wcs.wcs.ctype
+        new_wcs.wcs.crval = wcs.wcs.crval
+        new_wcs.wcs.crpix = wcs.wcs.crpix
+        new_wcs.wcs.pc = calculate_pc_matrix(crota, (cdelt1, cdelt2))
+        new_wcs.wcs.cdelt = (-cdelt1, cdelt2)
+        new_wcs.wcs.cunit = 'deg', 'deg'
+        return new_wcs
+    else:  # noqa RET505
+        return wcs
+
+def extract_crota_from_wcs(wcs: WCS) -> u.deg:
+    """Extract CROTA from a WCS."""
+    if hasattr(wcs.wcs, 'pc'):
+        delta_ratio = wcs.wcs.cdelt[1] / wcs.wcs.cdelt[0]
+        return np.arctan2(wcs.wcs.pc[1, 0]/delta_ratio, wcs.wcs.pc[0, 0]) * u.rad
+    elif hasattr(wcs.wcs, 'cd'):
+        new_wcs = convert_cd_matrix_to_pc_matrix(wcs)
+        return extract_crota_from_wcs(new_wcs)
+    else:
+        return 0 * u.rad

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,8 +62,6 @@ def test_determine_input_kind_fail(example_fail):
 def test_check_all_paths_resolve(request):
     for source_system in System:
         for target_system in System:
-            # source_system = System.npol
-            # target_system = System.bpb
             if source_system != target_system:  # don't need to convert if the input and output systems are the same
                 try:
                     path = get_transform_path(source_system, target_system)


### PR DESCRIPTION
## PR summary

- Makes IMAX matrix use WCS to find extent
- Makes IMAX effect include reference offsets
- Renames offset angle to reference angle

## TODO
- [ ] make sure this fully handles NFI, specifically if you don't do IMAX effect does the satellite angle get transformed?
- [ ] make sure changes are tested
- [ ] resolve unit issue on [this line](https://github.com/punch-mission/solpolpy/blob/1aee7511e8f42a488327134743439dd4753690e8/solpolpy/transforms.py#L455)
- [ ] make needed documentation changes

## Notes

@s0larish you told me to add `u.deg` to the `input_angle` in [this line](https://github.com/punch-mission/solpolpy/blob/1aee7511e8f42a488327134743439dd4753690e8/solpolpy/transforms.py#L455). I reverted the change because it breaks solpolpy's tests. Those tests already have it in degrees so adding your unit makes it degrees squared. We should check your usage in punchbowl. For solpolpy, meta should always have units and be a dictionary. Closing #146 should help you avoid this mistake. To make this easier in punchbowl, we could add a `to_dict` function on `NormalizedMetadata` so you don't have to jump through hoops with headers. 

@s0larish can we just run the IMAX effect on NFI anyway? Like the effect is tiny but using it wouldn't cause a problem, right? It would simplify code changes in punchbowl.  

## Issues

Closes #174 