### PR TITLE
Fixing key for npol conversion with 2D target angles

### DIFF
--- a/changelog/202.feature.rst
+++ b/changelog/202.feature.rst
@@ -1,0 +1,1 @@
+Modified NDCube Keys for npol to support 2D target angle arrays

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -465,7 +465,11 @@ def mzpsolar_to_npol(input_collection, out_angles: u.degree, reference_angle=0 *
                                      for input_angle, input_cube in input_dict.items()], axis=0)
         out_meta = copy.copy(first_meta)
         out_meta.update(POLAR=out_angle)
-        output_cubes.append((str(out_angle),
+        if out_angle.ndim > 1:
+            key = str(np.mean(out_angle))
+        else:
+            key = str(out_angle)
+        output_cubes.append((key,
                            NDCube(value, wcs=first_wcs, mask=mask, meta=out_meta)))
 
     if "alpha" in input_collection:

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -465,7 +465,7 @@ def mzpsolar_to_npol(input_collection, out_angles: u.degree, reference_angle=0 *
                                      for input_angle, input_cube in input_dict.items()], axis=0)
         out_meta = copy.copy(first_meta)
         out_meta.update(POLAR=out_angle)
-        if out_angle.ndim > 1:
+        if out_angles.ndim > 1:
             key = str(np.round(np.mean(out_angle).value))
         else:
             key = str(out_angle)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -466,7 +466,7 @@ def mzpsolar_to_npol(input_collection, out_angles: u.degree, reference_angle=0 *
         out_meta = copy.copy(first_meta)
         out_meta.update(POLAR=out_angle)
         if out_angle.ndim > 1:
-            key = str(np.mean(out_angle))
+            key = str(np.round(np.mean(out_angle).value))
         else:
             key = str(out_angle)
         output_cubes.append((key,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -213,6 +213,20 @@ def test_mzp_to_npol_custom():
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)
 
+def test_mzp_to_npol_many_angles():
+    """M, Z, P = 0, 1, 0 conversion"""
+    input_data = NDCollection(
+        [("P", NDCube(np.array([[1, 2], [3, 4]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+         ("Z", NDCube(np.array([[5, 6], [7, 8]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+         ("M", NDCube(np.array([[9, 10], [11, 12]]), wcs=wcs, meta={"POLAR": -60 * u.degree}))],
+        meta={}, aligned_axes="all")
+    actual = transforms.mzpsolar_to_npol(input_data, out_angles= np.stack([[0, 45], [-60, -15], [60, 105]]) * u.degree)
+
+    expected_keys = [str(22.0), str(-38.0), str(82.0)]
+
+    for k in range(3):
+        assert list(actual)[k] == expected_keys[k]
+
 
 @fixture()
 def fourpol_ones():


### PR DESCRIPTION

Target output angles ofr npol was based on single element as an angle.
If target angles is a 2d array (e.g. in case of PUNCH), NDcubes' keys are now modified to store an average value.