### PR TITLE
Calculate latitudes only once

### DIFF
--- a/changelog/205.feature.rst
+++ b/changelog/205.feature.rst
@@ -1,0 +1,1 @@
+Calculate latitudes only once when resolving polarization of a triplet.

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -15,7 +15,7 @@ import numpy as np
 from ndcube import NDCollection, NDCube
 
 from solpolpy.errors import InvalidDataError, MissingAlphaError, SolpolpyError
-from solpolpy.util import combine_all_collection_masks, extract_crota_from_wcs, solnorth_from_wcs
+from solpolpy.util import combine_all_collection_masks, extract_crota_from_wcs, solnorth_from_wcs, compute_lats
 
 System = StrEnum("System", ["bpb", "npol", "stokes", "mzpsolar", "mzpinstru", "btbr", "bthp", "fourpol", "bp3"])
 SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},
@@ -57,6 +57,7 @@ def transform(source_system, target_system, use_alpha):
         wrapper.uses_out_angles = uses_out_angles
         wrapper.uses_in_angles = uses_in_angles
         wrapper.uses_alpha = use_alpha
+        wrapper.fcn = transform_function
         return wrapper
     return decorator
 
@@ -577,12 +578,13 @@ def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs
 
      data_shape = input_collection[input_keys[0]].data.shape
 
-     angle_solar_north_m = (solnorth_from_wcs(input_collection['M'].wcs, shape=data_shape) + 60 * u.degree +
-                            polarizer_difference['M']) % (-180 * u.degree)
-     angle_solar_north_z = (solnorth_from_wcs(input_collection['Z'].wcs, shape=data_shape) + polarizer_difference[
-         'Z']) % (180 * u.degree)
-     angle_solar_north_p = (solnorth_from_wcs(input_collection['P'].wcs, shape=data_shape) - 60 * u.degree +
-                            polarizer_difference['P']) % (180 * u.degree)
+     lats = compute_lats(input_collection['Z'].wcs, data_shape)
+     angle_solar_north_m = (solnorth_from_wcs(input_collection['M'].wcs, shape=data_shape, precomputed_lats=lats)
+                            + (60 * u.degree + polarizer_difference['M'])) % (-180 * u.degree)
+     angle_solar_north_z = (solnorth_from_wcs(input_collection['Z'].wcs, shape=data_shape, precomputed_lats=lats)
+                            + polarizer_difference['Z']) % (180 * u.degree)
+     angle_solar_north_p = (solnorth_from_wcs(input_collection['P'].wcs, shape=data_shape, precomputed_lats=lats)
+                            - (60 * u.degree + polarizer_difference['P'])) % (180 * u.degree)
 
      out_angles = np.stack([angle_solar_north_m, angle_solar_north_z, angle_solar_north_p])
 

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -15,7 +15,7 @@ import numpy as np
 from ndcube import NDCollection, NDCube
 
 from solpolpy.errors import InvalidDataError, MissingAlphaError, SolpolpyError
-from solpolpy.util import combine_all_collection_masks, extract_crota_from_wcs, solnorth_from_wcs, compute_lats
+from solpolpy.util import combine_all_collection_masks, compute_lats, extract_crota_from_wcs, solnorth_from_wcs
 
 System = StrEnum("System", ["bpb", "npol", "stokes", "mzpsolar", "mzpinstru", "btbr", "bthp", "fourpol", "bp3"])
 SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -206,7 +206,18 @@ def collection_to_maps(collection):
     return sunpy_maps
 
 
-def solnorth_from_wcs(input_wcs, shape):
+def compute_lats(wcs, shape):
+    nrows, ncols = shape
+    y, x = np.mgrid[0:nrows, 0:ncols]
+
+    # Get solar coordinates (Tx, Ty) for each pixel
+    coords = pixel_to_skycoord(x, y, wcs)
+    lat = coords.Ty.to_value(u.deg)  # solar Y
+    return lat
+
+
+
+def solnorth_from_wcs(input_wcs, shape, precomputed_lats=None):
     """
     Compute the angle of solar north direction at each pixel using the solar WCS.
 
@@ -224,12 +235,10 @@ def solnorth_from_wcs(input_wcs, shape):
         Angle in degrees from +Y image axis to solar north at each pixel (measured counterclockwise).
     """
 
-    nrows, ncols = shape
-    y, x = np.mgrid[0:nrows, 0:ncols]
-
-    # Get solar coordinates (Tx, Ty) for each pixel
-    coords = pixel_to_skycoord(x, y, input_wcs)
-    lat = coords.Ty.to_value(u.deg)  # solar Y
+    if precomputed_lats is None:
+        lat = compute_lats(input_wcs, shape)
+    else:
+        lat = precomputed_lats
 
     # Compute gradient of solar latitude (points toward solar north)
     dy_lat, dx_lat = np.gradient(lat)


### PR DESCRIPTION
Most of the time in polarization resolution is in coordinates work. We're necessarily assuming the pointing is identical across the triplet, so we only need to compute the latitudes once, which cuts our resolution time in half.