### PR TITLE
Bugfixes for mzpsolar_to_mzpinstru

### DIFF
--- a/changelog/206.bugfix.2.rst
+++ b/changelog/206.bugfix.2.rst
@@ -1,0 +1,1 @@
+Properly order the layers for resolution.

--- a/changelog/206.bugfix.rst
+++ b/changelog/206.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfixes for mzpsolar_to_mzpinstru and updating tests

--- a/changelog/206.bugfix.rst
+++ b/changelog/206.bugfix.rst
@@ -1,1 +1,1 @@
-Bugfixes for mzpsolar_to_mzpinstru and updating tests
+mzpsolar_to_mzpinstru now handles per pixel calculation of solar north.

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -545,7 +545,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
         value = (1 / 3) * np.sum(
             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, input_cube in input_dict.items()], axis=0)
-        out_meta = copy.copy(input_collection[key].meta)
+        out_meta = copy.deepcopy(input_collection[key].meta)
         out_meta.update(POLARREF="Instrument")
         output_cubes.append((key,
                              NDCube(value, wcs=input_collection[key].wcs, mask=mask, meta=out_meta)))
@@ -596,7 +596,7 @@ def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs
          value = (1 / 3) * np.sum(
              [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
               for input_angle, input_cube in input_dict.items()], axis=0)
-         out_meta = copy.copy(first_meta)
+         out_meta = copy.deepcopy(first_meta)
          out_meta['POLARREF'] = "Solar"
          output_cubes.append((key,
                               NDCube(value, wcs=first_wcs, mask=mask, meta=out_meta)))

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -105,7 +105,7 @@ def npol_to_mzpsolar(input_collection, in_angles: u.degree = None, reference_ang
         meta.update({
             'POLAR': target_angle,
             'POLARREF': "Solar",
-            "POLAROFF": input_collection[original_angle].meta.get("POLAROFF", 0 * u.degree)
+            "POLAROFF": input_collection[original_angle].meta.get("POLAROFF", 0 )
         })
 
     mask = combine_all_collection_masks(input_collection)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -15,7 +15,7 @@ import numpy as np
 from ndcube import NDCollection, NDCube
 
 from solpolpy.errors import InvalidDataError, MissingAlphaError, SolpolpyError
-from solpolpy.util import combine_all_collection_masks, compute_lats, extract_crota_from_wcs, solnorth_from_wcs
+from solpolpy.util import combine_all_collection_masks, compute_lats, solnorth_from_wcs
 
 System = StrEnum("System", ["bpb", "npol", "stokes", "mzpsolar", "mzpinstru", "btbr", "bthp", "fourpol", "bp3"])
 SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -537,7 +537,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
 
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
-    satellite_orientation = extract_crota_from_wcs(input_collection['Z'])
+    satellite_orientation = extract_crota_from_wcs(input_collection['Z'].wcs)
     mzp_angles = [input_collection[key].meta['POLAR'] for key in input_collection.keys() if key != 'alpha']*u.degree
     out_angles = mzp_angles + satellite_orientation
 

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -544,7 +544,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
         value = (1 / 3) * np.sum(
             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, input_cube in input_dict.items()], axis=0)
-        out_meta = copy.copy(input_collection[key].meta)
+        out_meta = copy.deepcopy(input_collection[key].meta)
         out_meta.update(POLARREF="Instrument")
         output_cubes.append((key,
                              NDCube(value, wcs=input_collection[key].wcs, mask=mask, meta=out_meta)))
@@ -594,7 +594,7 @@ def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs
          value = (1 / 3) * np.sum(
              [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
               for input_angle, input_cube in input_dict.items()], axis=0)
-         out_meta = copy.copy(first_meta)
+         out_meta = copy.deepcopy(first_meta)
          out_meta['POLARREF'] = "Solar"
          output_cubes.append((key,
                               NDCube(value, wcs=first_wcs, mask=mask, meta=out_meta)))

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -538,10 +538,10 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
     satellite_orientation = extract_crota_from_wcs(input_collection['Z'])
-    mzp_angles = [input_collection[key].meta['POLAR'] for key in list(input_collection.keys()) if key != 'alpha']*u.degree
+    mzp_angles = [input_collection[key].meta['POLAR'] for key in input_collection.keys() if key != 'alpha']*u.degree
     out_angles = mzp_angles + satellite_orientation
 
-    for out_angle, key in zip(out_angles, ["M", "Z", "P"]):
+    for out_angle, key in zip(out_angles, input_collection.keys()):
         value = (1 / 3) * np.sum(
             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, input_cube in input_dict.items()], axis=0)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -537,10 +537,10 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
     satellite_orientation = extract_crota_from_wcs(input_collection['Z'])
-    mzp_angles = [input_collection[key].meta['POLAR'] for key in list(input_collection.keys()) if key != 'alpha']*u.degree
+    mzp_angles = [input_collection[key].meta['POLAR'] for key in input_collection.keys() if key != 'alpha']*u.degree
     out_angles = mzp_angles + satellite_orientation
 
-    for out_angle, key in zip(out_angles, ["M", "Z", "P"]):
+    for out_angle, key in zip(out_angles, input_collection.keys()):
         value = (1 / 3) * np.sum(
             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, input_cube in input_dict.items()], axis=0)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -535,18 +535,29 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
             break
         input_dict[input_collection[p_angle].meta["POLAR"]] = input_collection[p_angle].data
 
+    input_keys = list(input_collection.keys())
+    polarizer_difference = {k: input_collection[k].meta['POLAROFF'] * u.degree if 'POLAROFF' in input_collection[
+         k].meta else 0 * u.degree for k in ['M', 'Z', 'P']}
+
+    data_shape = input_collection[input_keys[0]].data.shape
+
+    lats = compute_lats(input_collection['Z'].wcs, data_shape)
+    angle_solar_north_m = (solnorth_from_wcs(input_collection['M'].wcs, shape=data_shape, precomputed_lats=lats)
+                           + (60 * u.degree + polarizer_difference['M'])) % (-180 * u.degree)
+    angle_solar_north_z = (solnorth_from_wcs(input_collection['Z'].wcs, shape=data_shape, precomputed_lats=lats)
+                           + polarizer_difference['Z']) % (180 * u.degree)
+    angle_solar_north_p = (solnorth_from_wcs(input_collection['P'].wcs, shape=data_shape, precomputed_lats=lats)
+                           - (60 * u.degree + polarizer_difference['P'])) % (180 * u.degree)
+    in_angles = np.stack([angle_solar_north_m, angle_solar_north_z, angle_solar_north_p])
+
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
-    satellite_orientation = extract_crota_from_wcs(input_collection['Z'].wcs)
-    mzp_angles = [input_collection[key].meta['POLAR'] for key in ["M", "P", "Z"] if key != 'alpha']*u.degree
-    out_angles = mzp_angles + satellite_orientation
-
-    for out_angle, key in zip(out_angles, ["M", "P", "Z"]):
+    for out_angle, key in zip([-60, 0, 60] * u.deg, ["M", "Z", "P"]):
         value = (1 / 3) * np.sum(
-            [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
-             for input_angle, input_cube in input_dict.items()], axis=0)
+            [input_collection[angle].data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
+             for input_angle, angle in zip(in_angles, ["M", "Z", "P"])], axis=0)
         out_meta = copy.deepcopy(input_collection[key].meta)
-        out_meta.update(POLARREF="Instrument")
+        out_meta['POLARREF'] = "Solar"
         output_cubes.append((key,
                              NDCube(value, wcs=input_collection[key].wcs, mask=mask, meta=out_meta)))
 

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -538,10 +538,10 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
     satellite_orientation = extract_crota_from_wcs(input_collection['Z'].wcs)
-    mzp_angles = [input_collection[key].meta['POLAR'] for key in input_collection.keys() if key != 'alpha']*u.degree
+    mzp_angles = [input_collection[key].meta['POLAR'] for key in ["M", "P", "Z"] if key != 'alpha']*u.degree
     out_angles = mzp_angles + satellite_orientation
 
-    for out_angle, key in zip(out_angles, input_collection.keys()):
+    for out_angle, key in zip(out_angles, ["M", "P", "Z"]):
         value = (1 / 3) * np.sum(
             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, input_cube in input_dict.items()], axis=0)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -536,7 +536,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
 
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
-    satellite_orientation = extract_crota_from_wcs(input_collection['Z'])
+    satellite_orientation = extract_crota_from_wcs(input_collection['Z'].wcs)
     mzp_angles = [input_collection[key].meta['POLAR'] for key in input_collection.keys() if key != 'alpha']*u.degree
     out_angles = mzp_angles + satellite_orientation
 

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -557,7 +557,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
             [input_collection[angle].data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, angle in zip(in_angles, ["M", "Z", "P"])], axis=0)
         out_meta = copy.deepcopy(input_collection[key].meta)
-        out_meta['POLARREF'] = "Solar"
+        out_meta['POLARREF'] = "Instrument"
         output_cubes.append((key,
                              NDCube(value, wcs=input_collection[key].wcs, mask=mask, meta=out_meta)))
 

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -592,7 +592,7 @@ def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs
      mask = combine_all_collection_masks(input_collection)
      first_meta = input_collection[in_list[0]].meta
      first_wcs = input_collection[in_list[0]].wcs
-     for out_angle, key in zip(out_angles, ["M", "P", "Z"]):
+     for out_angle, key in zip(out_angles, ["M", "Z", "P"]):
          value = (1 / 3) * np.sum(
              [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
               for input_angle, input_cube in input_dict.items()], axis=0)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -537,10 +537,10 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
     output_cubes = []
     mask = combine_all_collection_masks(input_collection)
     satellite_orientation = extract_crota_from_wcs(input_collection['Z'].wcs)
-    mzp_angles = [input_collection[key].meta['POLAR'] for key in input_collection.keys() if key != 'alpha']*u.degree
+    mzp_angles = [input_collection[key].meta['POLAR'] for key in ["M", "P", "Z"] if key != 'alpha']*u.degree
     out_angles = mzp_angles + satellite_orientation
 
-    for out_angle, key in zip(out_angles, input_collection.keys()):
+    for out_angle, key in zip(out_angles, ["M", "P", "Z"]):
         value = (1 / 3) * np.sum(
             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
              for input_angle, input_cube in input_dict.items()], axis=0)

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -248,7 +248,7 @@ def solnorth_from_wcs(input_wcs, shape, precomputed_lats=None):
     north_dx = dx_lat / norm
     north_dy = dy_lat / norm
 
-    # angle from horizontal +X direction
+    # angle from +Y direction
     angle_solar_north = np.degrees(np.arctan2(north_dy, north_dx)) - 90
 
     return angle_solar_north * u.degree

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -245,6 +245,7 @@ def solnorth_from_wcs(input_wcs, shape, precomputed_lats=None):
 
     # Normalize vectors
     norm = np.hypot(dx_lat, dy_lat)
+    norm[norm == 0] = np.nan
     north_dx = dx_lat / norm
     north_dy = dy_lat / norm
 

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -239,7 +239,7 @@ def solnorth_from_wcs(input_wcs, shape):
     north_dx = dx_lat / norm
     north_dy = dy_lat / norm
 
-    # angle from horizontal +X direction
+    # angle from +Y direction
     angle_solar_north = np.degrees(np.arctan2(north_dy, north_dx)) - 90
 
     return angle_solar_north * u.degree

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,17 +1,35 @@
 import astropy.units as u
 import astropy.wcs
+from astropy.io import fits
 import numpy as np
 from ndcube import NDCollection, NDCube
 from pytest import fixture
 
 from solpolpy.util import make_empty_distortion_model
 
-wcs = astropy.wcs.WCS(naxis=3)
-wcs.ctype = "WAVE", "HPLT-TAN", "HPLN-TAN"
-wcs.cdelt = 0.2, 0.5, 0.4
-wcs.cunit = "Angstrom", "deg", "deg"
-wcs.crpix = 2, 2, 2
-wcs.crval = 0, 0, 0
+# Solar WCS
+wcs_sol = astropy.wcs.WCS(naxis=2)
+wcs_sol.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+wcs_sol.wcs.cunit = "deg", "deg"
+wcs_sol.wcs.cdelt = 0.5, 0.4
+wcs_sol.wcs.crpix = 2, 2
+wcs_sol.wcs.crval = 0.5, 1
+wcs_sol.wcs.cname = "HPC lon", "HPC lat"
+
+# Celestial WCS
+wcs_cel = astropy.wcs.WCS(naxis=2)
+wcs_cel.wcs.ctype = "RA---TAN", "DEC--TAN"
+wcs_cel.wcs.cunit = "deg", "deg"
+wcs_cel.wcs.cdelt = -0.5, 0.4
+wcs_cel.wcs.crpix = 2.0, 2.0
+wcs_cel.wcs.crval = 10.0, 20.0
+wcs_cel.wcs.cname = "RA", "DEC"
+
+hdr = fits.Header()
+hdr.update(wcs_sol.to_header())
+hdr.update(wcs_cel.to_header(key="A"))
+
+wcs = astropy.wcs.WCS(hdr)
 
 wcs_new = astropy.wcs.WCS(naxis=2)
 wcs_new.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
@@ -23,28 +41,31 @@ wcs_new.wcs.cname = "HPC lon", "HPC lat"
 
 @fixture()
 def npol_ones():
+    data, _ = np.mgrid[0:5, 0:5]
     data_out = [
-        (str(60 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "OBSRVTRY": "LASCO"})),
-        (str(0 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "OBSRVTRY": "LASCO"})),
-        (str(-60 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "OBSRVTRY": "LASCO"}))]
-    # data_out.append(("alpha", NDCube(np.array([0])*u.radian, wcs=wcs)))
+        (str(60 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": 60 * u.degree, "OBSRVTRY": "LASCO"})),
+        (str(0 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": 0 * u.degree, "OBSRVTRY": "LASCO"})),
+        (str(-60 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": -60 * u.degree, "OBSRVTRY": "LASCO"}))]
+    data_out.append(("alpha", NDCube(np.full((5,5), 0), wcs=wcs)))
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def fourpol_ones():
-    data_out = [(str(0 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
-                (str(45 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 45 * u.degree})),
-                (str(90 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 90 * u.degree})),
-                (str(135 * u.degree), NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 135 * u.degree}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [(str(0 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": 0 * u.degree})),
+                (str(45 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": 45 * u.degree})),
+                (str(90 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": 90 * u.degree})),
+                (str(135 * u.degree), NDCube(data, wcs=wcs, meta={"POLAR": 135 * u.degree}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def mzpsolar_ones():
-    data_out = [("P", NDCube(np.array([[1.0]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLARREF": 'Solar'})),
-                ("Z", NDCube(np.array([[1.0]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLARREF": 'Solar'})),
-                ("M", NDCube(np.array([[1.0]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLARREF": 'Solar'}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("P", NDCube(data, wcs=wcs, meta={"POLAR": 60 * u.degree, "POLARREF": 'Solar'})),
+                ("Z", NDCube(data, wcs=wcs, meta={"POLAR": 0 * u.degree, "POLARREF": 'Solar'})),
+                ("M", NDCube(data, wcs=wcs, meta={"POLAR": -60 * u.degree, "POLARREF": 'Solar'}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
@@ -61,9 +82,10 @@ def mzpsolar_degenerate():
 
 @fixture()
 def mzp_ones_other_order():
-    data_out = [("Z", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLARREF": 'Solar'})),
-                ("P", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLARREF": 'Solar'})),
-                ("M", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLARREF": 'Solar'}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("Z", NDCube(data, wcs=wcs, meta={"POLAR": 0 * u.degree, "POLARREF": 'Solar'})),
+                ("P", NDCube(data, wcs=wcs, meta={"POLAR": 60 * u.degree, "POLARREF": 'Solar'})),
+                ("M", NDCube(data, wcs=wcs, meta={"POLAR": -60 * u.degree, "POLARREF": 'Solar'}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
@@ -76,81 +98,90 @@ def bpb_data():
 
 @fixture()
 def mzpsolar_ones_alpha():
-    data_out = [("P", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
-                ("Z", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
-                ("M", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
-                ("alpha", NDCube(np.array([0]), wcs=wcs))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("P", NDCube(data, wcs=wcs, meta={"POLAR": 60 * u.degree})),
+                ("Z", NDCube(data, wcs=wcs, meta={"POLAR": 0 * u.degree})),
+                ("M", NDCube(data, wcs=wcs, meta={"POLAR": -60 * u.degree})),
+                ("alpha", NDCube(np.full((5,5), 0)* u.degree, wcs=wcs))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def bpb_zeros():
-    data_out = [("B", NDCube(np.array([0]), wcs=wcs, meta={"POLAR": "B"})),
-                ("pB", NDCube(np.array([0]), wcs=wcs, meta={"POLAR": "pB"})),
-                ("alpha", NDCube(np.array([0]) * u.degree, wcs=wcs))]
+    data_out = [("B", NDCube(np.full((5,5), 0), wcs=wcs, meta={"POLAR": "B"})),
+                ("pB", NDCube(np.full((5,5), 0), wcs=wcs, meta={"POLAR": "pB"})),
+                ("alpha", NDCube(np.full((5,5), 0) , wcs=wcs))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def bpb_ones():
-    data_out = [("B", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "B"})),
-                ("pB", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "pB"})),
-                ("alpha", NDCube(np.array([[0]]), wcs=wcs))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("B", NDCube(data, wcs=wcs, meta={"POLAR": "B"})),
+                ("pB", NDCube(data, wcs=wcs, meta={"POLAR": "pB"})),
+                ("alpha", NDCube(np.full((5,5), 0), wcs=wcs))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def bpb_ones_no_alpha():
-    data_out = [("B", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "B"})),
-                ("pB", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "pB"}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("B", NDCube(data, wcs=wcs, meta={"POLAR": "B"})),
+                ("pB", NDCube(data, wcs=wcs, meta={"POLAR": "pB"}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def btbr_ones():
-    data_out = [("Bt", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "Bt"})),
-                ("Br", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "Br"})),
-                ("alpha", NDCube(np.array([[0]]) * u.degree, wcs=wcs))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("Bt", NDCube(data, wcs=wcs, meta={"POLAR": "Bt"})),
+                ("Br", NDCube(data, wcs=wcs, meta={"POLAR": "Br"})),
+                ("alpha", NDCube(np.full((5,5), 0) , wcs=wcs))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def btbr_ones_no_alpha():
-    data_out = [("Bt", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "Bt"})),
-                ("Br", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "Br"}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("Bt", NDCube(data, wcs=wcs, meta={"POLAR": "Bt"})),
+                ("Br", NDCube(data, wcs=wcs, meta={"POLAR": "Br"}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def stokes_ones():
-    data_out = [("I", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "I"})),
-                ("Q", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "Q"})),
-                ("U", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "U"}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("I", NDCube(data, wcs=wcs, meta={"POLAR": "I"})),
+                ("Q", NDCube(data, wcs=wcs, meta={"POLAR": "Q"})),
+                ("U", NDCube(data, wcs=wcs, meta={"POLAR": "U"}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def bp3_ones():
-    data_out = [("B", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "B"})),
-                ("pB", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "pB"})),
-                ("pBp", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": "pBp"})),
-                ("alpha", NDCube(np.array([[0]]) * u.degree, wcs=wcs))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("B", NDCube(data, wcs=wcs, meta={"POLAR": "B"})),
+                ("pB", NDCube(data, wcs=wcs, meta={"POLAR": "pB"})),
+                ("pBp", NDCube(data, wcs=wcs, meta={"POLAR": "pBp"})),
+                ("alpha", NDCube(np.full((5,5), 0) , wcs=wcs))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def bp3_ones_no_alpha():
-    data_out = [("B", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "B"})),
-                ("pB", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "pB"})),
-                ("pBp", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "pBp"}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("B", NDCube(data, wcs=wcs, meta={"POLAR": "B"})),
+                ("pB", NDCube(data, wcs=wcs, meta={"POLAR": "pB"})),
+                ("pBp", NDCube(data, wcs=wcs, meta={"POLAR": "pBp"}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
 @fixture()
 def bthp_ones():
-    data_out = [("B", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "B"})),
-                ("theta", NDCube(np.array([1]) * u.degree, wcs=wcs, meta={"POLAR": "Theta"})),
-                ("p", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "Degree of Polarization"}))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("B", NDCube(data, wcs=wcs, meta={"POLAR": "B"})),
+                ("theta", NDCube(data * u.degree, wcs=wcs, meta={"POLAR": "Theta"})),
+                ("p", NDCube(data, wcs=wcs, meta={"POLAR": "Degree of Polarization"}))]
     return NDCollection(data_out, meta={}, aligned_axes="all")
 
 
@@ -188,7 +219,8 @@ def mzpinstru_distortion():
 
 @fixture()
 def example_fail():
-    data_out = [("B", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "B"})),
-                ("Bm", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": "Bm"})),
-                ("alpha", NDCube(np.array([0]) * u.degree, wcs=wcs))]
+    data, _ = np.mgrid[0:5, 0:5]
+    data_out = [("B", NDCube(data, wcs=wcs, meta={"POLAR": "B"})),
+                ("Bm", NDCube(data, wcs=wcs, meta={"POLAR": "Bm"})),
+                ("alpha", NDCube(np.full((5,5), 0) , wcs=wcs))]
     return NDCollection(data_out, meta={}, aligned_axes="all")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,7 @@
 import astropy.units as u
 import astropy.wcs
-from astropy.io import fits
 import numpy as np
+from astropy.io import fits
 from ndcube import NDCollection, NDCube
 from pytest import fixture
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,9 +3,9 @@
 
 import astropy.units as u
 import astropy.wcs
-from astropy.io import fits
 import numpy as np
 import pytest
+from astropy.io import fits
 from ndcube import NDCollection, NDCube
 
 from solpolpy.core import _determine_image_shape, add_alpha, determine_input_kind, get_transform_path, resolve

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@
 
 import astropy.units as u
 import astropy.wcs
+from astropy.io import fits
 import numpy as np
 import pytest
 from ndcube import NDCollection, NDCube
@@ -12,12 +13,29 @@ from solpolpy.errors import UnsupportedTransformationError
 from solpolpy.transforms import System
 from tests.fixtures import *
 
-wcs = astropy.wcs.WCS(naxis=3)
-wcs.ctype = "WAVE", "HPLT-TAN", "HPLN-TAN"
-wcs.cdelt = 0.2, 0.5, 0.4
-wcs.cunit = "Angstrom", "deg", "deg"
-wcs.crpix = 0, 2, 2
-wcs.crval = 10, 0.5, 1
+# Solar WCS
+wcs_sol = astropy.wcs.WCS(naxis=2)
+wcs_sol.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+wcs_sol.wcs.cunit = "deg", "deg"
+wcs_sol.wcs.cdelt = 0.5, 0.4
+wcs_sol.wcs.crpix = 2, 2
+wcs_sol.wcs.crval = 0.5, 1
+wcs_sol.wcs.cname = "HPC lon", "HPC lat"
+
+# Celestial WCS
+wcs_cel = astropy.wcs.WCS(naxis=2)
+wcs_cel.wcs.ctype = "RA---TAN", "DEC--TAN"
+wcs_cel.wcs.cunit = "deg", "deg"
+wcs_cel.wcs.cdelt = -0.5, 0.4
+wcs_cel.wcs.crpix = 2.0, 2.0
+wcs_cel.wcs.crval = 10.0, 20.0
+wcs_cel.wcs.cname = "RA", "DEC"
+
+hdr = fits.Header()
+hdr.update(wcs_sol.to_header())
+hdr.update(wcs_cel.to_header(key="A"))
+
+wcs = astropy.wcs.WCS(hdr)
 
 
 def test_determine_image_shape():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2,6 +2,7 @@ import astropy.units as u
 import astropy.wcs
 import numpy as np
 import pytest
+from astropy.io import fits
 from ndcube import NDCollection, NDCube
 from pytest import fixture
 
@@ -303,13 +304,29 @@ def test_fourpol_to_stokes_ones(fourpol_ones):
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)
 
-wcs_new = astropy.wcs.WCS(naxis=2)
-wcs_new.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
-wcs_new.wcs.cunit = "deg", "deg"
-wcs_new.wcs.cdelt = 0.5, 0.4
-wcs_new.wcs.crpix = 2, 2
-wcs_new.wcs.crval = 0.5, 1
-wcs_new.wcs.cname = "HPC lon", "HPC lat"
+# Solar WCS
+wcs_sol = astropy.wcs.WCS(naxis=2)
+wcs_sol.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+wcs_sol.wcs.cunit = "deg", "deg"
+wcs_sol.wcs.cdelt = 0.5, 0.4
+wcs_sol.wcs.crpix = 2, 2
+wcs_sol.wcs.crval = 0.5, 1
+wcs_sol.wcs.cname = "HPC lon", "HPC lat"
+
+# Celestial WCS
+wcs_cel = astropy.wcs.WCS(naxis=2)
+wcs_cel.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+wcs_cel.wcs.cunit = ["deg", "deg"]
+wcs_cel.wcs.cdelt = [-0.5, 0.4]
+wcs_cel.wcs.crpix = [2.0, 2.0]
+wcs_cel.wcs.crval = [10.0, 20.0]
+wcs_cel.wcs.cname = ["RA", "DEC"]
+
+hdr = fits.Header()
+hdr.update(wcs_sol.to_header())
+hdr.update(wcs_cel.to_header(key="A"))
+
+wcs_new = astropy.wcs.WCS(hdr)
 
 @fixture()
 def mzp_ones_instru():
@@ -326,9 +343,9 @@ def test_mzp_mzp_ones_instru(mzp_ones_instru):
     actual = transforms.mzpinstru_to_mzpsolar(mzp_ones_instru)
     data, _ = np.mgrid[0:5, 0:5]
     expected_data = [
-        ("M", NDCube(data, wcs=wcs, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
-        ("Z", NDCube(data, wcs=wcs, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
-        ("P", NDCube(data, wcs=wcs, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'}))]
+        ("M", NDCube(data, wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
+        ("Z", NDCube(data, wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
+        ("P", NDCube(data, wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'}))]
     expected = NDCollection(expected_data, meta={}, aligned_axes="all")
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data, atol=1.e-5)
@@ -337,22 +354,29 @@ def test_mzp_mzp_ones_instru(mzp_ones_instru):
 @fixture()
 def mzp_ones_solar():
     input_data = NDCollection(
-        [("P", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
-         ("Z", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
-         ("M", NDCube(np.array([[1]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'}))],
+        [("P", NDCube(np.array([[1, 2], [2, 4]]), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
+         ("Z", NDCube(np.array([[1, 2], [2, 4]]), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
+         ("M", NDCube(np.array([[1, 2], [2, 4]]), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'}))],
         meta={}, aligned_axes="all")
     return input_data
 
 def test_mzp_mzp_ones_solar(mzp_ones_solar):
     actual = transforms.mzpsolar_to_mzpinstru(mzp_ones_solar)
     expected_data = [
-        ("M", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'})),
-        ("Z", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'})),
-        ("P", NDCube(np.array([1]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'}))]
+        ("M", NDCube(np.array([[0.99, 1.99], [1.99, 3.99]]), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'})),
+        ("Z", NDCube(np.array([[0.95, 1.91], [1.91, 3.83]]), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'})),
+        ("P", NDCube(np.array([[1.04, 2.08], [2.08, 4.16]]), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'}))]
     expected = NDCollection(expected_data, meta={}, aligned_axes="all")
     for k in list(expected):
-        assert np.allclose(actual[str(k)].data, expected[str(k)].data)
+        assert np.allclose(actual[str(k)].data, expected[str(k)].data, atol=1.e-2)
         assert (actual[str(k)].meta["POLARREF"] == expected[str(k)].meta["POLARREF"])
+
+def test_mzp_two_ways(mzp_ones_instru):
+    outsolar = transforms.mzpinstru_to_mzpsolar(mzp_ones_instru)
+    outinstru = transforms.mzpsolar_to_mzpinstru(outsolar)
+    assert np.allclose(outinstru["M"].data, mzp_ones_instru["M"].data, rtol=0.1)
+    assert np.allclose(outinstru["Z"].data, mzp_ones_instru["Z"].data, rtol=0.1)
+    assert np.allclose(outinstru["P"].data, mzp_ones_instru["P"].data, rtol=0.1)
 
 
 @fixture()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -315,12 +315,12 @@ wcs_sol.wcs.cname = "HPC lon", "HPC lat"
 
 # Celestial WCS
 wcs_cel = astropy.wcs.WCS(naxis=2)
-wcs_cel.wcs.ctype = ["RA---TAN", "DEC--TAN"]
-wcs_cel.wcs.cunit = ["deg", "deg"]
-wcs_cel.wcs.cdelt = [-0.5, 0.4]
-wcs_cel.wcs.crpix = [2.0, 2.0]
-wcs_cel.wcs.crval = [10.0, 20.0]
-wcs_cel.wcs.cname = ["RA", "DEC"]
+wcs_cel.wcs.ctype = "RA---TAN", "DEC--TAN"
+wcs_cel.wcs.cunit = "deg", "deg"
+wcs_cel.wcs.cdelt = -0.5, 0.4
+wcs_cel.wcs.crpix = 2.0, 2.0
+wcs_cel.wcs.crval = 10.0, 20.0
+wcs_cel.wcs.cname = "RA", "DEC"
 
 hdr = fits.Header()
 hdr.update(wcs_sol.to_header())

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -103,9 +103,9 @@ def test_btbr_mzp_ways(btbr_ones):
 def test_mzp_stokes_ones(mzpsolar_ones):
     actual = transforms.mzpsolar_to_stokes(mzpsolar_ones)
     expected_data = []
-    expected_data.append(("I", NDCube(np.array([2]), wcs=wcs)))
-    expected_data.append(("Q", NDCube(np.array([0]), wcs=wcs)))
-    expected_data.append(("U", NDCube(np.array([0]), wcs=wcs)))
+    expected_data.append(("I", NDCube(np.arange(0, 10, 2)[:, None] * np.ones((1, 5)), wcs=wcs)))
+    expected_data.append(("Q", NDCube(np.zeros((5,5)), wcs=wcs)))
+    expected_data.append(("U", NDCube(np.zeros((5,5)), wcs=wcs)))
     expected = NDCollection(expected_data, meta={}, aligned_axes="all")
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)


### PR DESCRIPTION
To make and use coronal backgrounds in the stray light estimation, we have to project the background back into the instrument frame and resolve it from solar MZP back to instrument MZP. Right now, `mzpsolar_to_mzpinstru` and `mzpinstru_to_mzpsolar` don't seem to round-trip. I think these changes to `mzpsolar_to_mzpinstru` are all correct, though not yet enough to make these functions inverses of each other. I think the big missing thing is that `mzpinstru_to_mzpsolar` computes things per-pixel, but `mzpsolar_to_mzpinstru` just uses the over-all spacecraft orientation without doing anything per-pixel. Chris and I looked at this for a while and couldn't figure out if/how to change it, though.