### PR TITLE
Fail for unrecognized POLARREF value

### DIFF
--- a/changelog/207.bugfix.rst
+++ b/changelog/207.bugfix.rst
@@ -1,0 +1,1 @@
+Fail if an unrecognized POLARREF value is passed in.

--- a/solpolpy/core.py
+++ b/solpolpy/core.py
@@ -120,7 +120,12 @@ def determine_input_kind(input_data: NDCollection) -> System:
     for valid_kind, param_set in SYSTEM_REQUIRED_KEYS.items():
         if valid_kind in [System.mzpinstru, System.mzpsolar] and param_set == input_keys:
             polarref_value = input_data['Z'].meta.get("POLARREF", "solar").lower()
-            return System.mzpinstru if polarref_value == "instrument" else System.mzpsolar
+            if polarref_value == "instrument":
+                return System.mzpinstru
+            elif polarref_value == "solar":
+              return System.mzpsolar
+            else:
+                raise ValueError(f"Unrecognized POALRREF value: {polarref_value}")
         if valid_kind != System.npol and param_set == input_keys:
             return valid_kind
     try:


### PR DESCRIPTION
I don't think this has caused anyone any trouble, but while I'm being paranoid about getting details right, should be we defaulting to solar MZP for unrecognized POLARREF values?