### PR TITLE
Improve DeForest 2022 polarization transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 
 *venv*
 .idea
+.vscode/settings.json

--- a/changelog/210.feature.rst
+++ b/changelog/210.feature.rst
@@ -1,0 +1,1 @@
+Add tested physics helpers for polarization transform math.

--- a/changelog/211.feature.rst
+++ b/changelog/211.feature.rst
@@ -1,1 +1,1 @@
-Document and tighten transform helper validation.
+Introduce wcs aware alpha; shifted conversions to physics folder; updated transforms.py

--- a/changelog/211.feature.rst
+++ b/changelog/211.feature.rst
@@ -1,0 +1,1 @@
+Document and tighten transform helper validation.

--- a/changelog/212.feature.rst
+++ b/changelog/212.feature.rst
@@ -1,0 +1,1 @@
+Replaced "Analyzer" with "Polarizer"

--- a/changelog/213.feature.rst
+++ b/changelog/213.feature.rst
@@ -1,0 +1,1 @@
+Added support for ASPIICS data

--- a/changelog/214.feature.rst
+++ b/changelog/214.feature.rst
@@ -1,0 +1,1 @@
+Refines equation-based polarization transform helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ length_sort_sections = "stdlib"
 line_length = 120
 multi_line_output = 3
 no_lines_before = "LOCALFOLDER"
-sections = "STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER"
+sections = "FUTURE, STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER"
 
 [tool.gilesbot]
 [tool.gilesbot.pull_requests]

--- a/solpolpy/alpha.py
+++ b/solpolpy/alpha.py
@@ -2,10 +2,12 @@
 
 import astropy.units as u
 import numpy as np
+import sunpy.coordinates  # noqa: F401
+from astropy.wcs.utils import pixel_to_skycoord
 
 
 def radial_north(shape):
-    """An alpha array oriented north.
+    """An alpha array referenced to north with counterclockwise-positive angles.
 
     Parameters
     ----------
@@ -21,16 +23,40 @@ def radial_north(shape):
     -----
     - assumes solar north is up
     - assumes polarizer 0 is along solar north axis
-    - creates radial polarization map
-    - angles increase in counterclockwise direction
+    - uses NumPy image indexing: row 0 is the top of the image, column 0 is the left
+    - returns the radial axis angle measured from north = 0, increasing counterclockwise
 
     """
-    x_size, y_size = shape
-    x = np.arange(-x_size // 2, x_size // 2)
-    y = np.arange(-y_size // 2, y_size // 2)
-    xx, yy = np.meshgrid(x, y)
-    return np.fliplr(np.rot90(np.flipud(np.arctan2(yy, xx)), k=1))*u.radian
+    nrows, ncols = shape
+    center_row = (nrows - 1) / 2.0
+    center_col = (ncols - 1) / 2.0
+
+    row_indices, col_indices = np.indices(shape, dtype=float)
+    dx = col_indices - center_col
+    dy_up = center_row - row_indices
+
+    # Angle from north with counterclockwise-positive rotation.
+    return np.arctan2(-dx, dy_up) * u.radian
+
+
+def radial_from_wcs(wcs, shape):
+    """Construct an alpha array from solar coordinates in the WCS.
+
+    This computes the radial direction from solar center for each pixel,
+    measured from solar north = 0 with counterclockwise-positive rotation.
+    For partial-frame images, this samples the relevant subset of the full
+    solar-centered alpha field instead of assuming the Sun is at image center.
+    """
+    nrows, ncols = shape
+    row_indices, col_indices = np.mgrid[0:nrows, 0:ncols]
+    coords = pixel_to_skycoord(col_indices, row_indices, wcs)
+
+    tx = coords.Tx.to_value(u.deg)
+    ty = coords.Ty.to_value(u.deg)
+
+    return np.arctan2(-tx, ty) * u.radian
 
 
 ALPHA_FUNCTIONS = {"radial_north": radial_north,
+                   "radial_from_wcs": radial_from_wcs,
                    "zeros": np.zeros}

--- a/solpolpy/alpha.py
+++ b/solpolpy/alpha.py
@@ -7,17 +7,17 @@ from astropy.wcs.utils import pixel_to_skycoord
 
 
 def radial_north(shape):
-    """An alpha array referenced to north with counterclockwise-positive angles.
+    """Construct an image-centered alpha angle field.
 
     Parameters
     ----------
     shape : tuple[int, int]
-        how big the array should be
+        Image shape as ``(nrows, ncols)``.
 
     Returns
     -------
     np.ndarray
-        alpha array used in calculations
+        Alpha angle field in radians.
 
     Notes
     -----
@@ -41,7 +41,7 @@ def radial_north(shape):
 
 
 def radial_from_wcs(wcs, shape):
-    """Construct an alpha array from solar coordinates in the WCS.
+    """Construct a WCS-aware alpha angle field.
 
     This computes the per-pixel alpha angle from helioprojective coordinates,
     with solar north = 0 and counterclockwise-positive rotation. For

--- a/solpolpy/alpha.py
+++ b/solpolpy/alpha.py
@@ -21,10 +21,11 @@ def radial_north(shape):
 
     Notes
     -----
-    - assumes solar north is up
-    - assumes polarizer 0 is along solar north axis
-    - uses NumPy image indexing: row 0 is the top of the image, column 0 is the left
-    - returns the radial axis angle measured from north = 0, increasing counterclockwise
+    - assumes solar north is up in the image
+    - assumes polarizer 0 is aligned with the solar north axis
+    - uses NumPy image indexing: row 0 is solar north/up, column 0 is left
+    - returns the per-pixel alpha angle with north = 0 and counterclockwise-positive rotation
+    - represents the simple image-centered form of the alpha field
 
     """
     nrows, ncols = shape
@@ -42,10 +43,11 @@ def radial_north(shape):
 def radial_from_wcs(wcs, shape):
     """Construct an alpha array from solar coordinates in the WCS.
 
-    This computes the radial direction from solar center for each pixel,
-    measured from solar north = 0 with counterclockwise-positive rotation.
-    For partial-frame images, this samples the relevant subset of the full
-    solar-centered alpha field instead of assuming the Sun is at image center.
+    This computes the per-pixel alpha angle from helioprojective coordinates,
+    with solar north = 0 and counterclockwise-positive rotation. For
+    partial-frame images, this samples the appropriate subset of the larger
+    solar-centered alpha field instead of assuming the Sun is centered in the
+    image array.
     """
     nrows, ncols = shape
     row_indices, col_indices = np.mgrid[0:nrows, 0:ncols]

--- a/solpolpy/constants.py
+++ b/solpolpy/constants.py
@@ -4,3 +4,5 @@ import astropy.units as u
 # offset angles come from https://www.sciencedirect.com/science/article/pii/S0019103515003620?via%3Dihub
 STEREOA_REFERENCE_ANGLE = 45.8 * u.degree
 STEREOB_REFERENCE_ANGLE = -18 * u.degree
+LASCO_REFERENCE_ANGLE = 90 * u.degree
+ASPIICS_REFERENCE_ANGLE = -90 * u.degree

--- a/solpolpy/core.py
+++ b/solpolpy/core.py
@@ -128,7 +128,7 @@ def determine_input_kind(input_data: NDCollection) -> System:
             elif polarref_value == "solar":
               return System.mzpsolar
             else:
-                raise ValueError(f"Unrecognized POALRREF value: {polarref_value}")
+                raise ValueError(f"Unrecognized POLARREF value: {polarref_value}")
         if valid_kind != System.npol and param_set == input_keys:
             return valid_kind
     try:
@@ -240,7 +240,10 @@ def add_alpha(input_data: NDCollection) -> NDCollection:
         dataset with alpha array appended
 
     """
-    # test if alpha exists. if not check if alpha keyword added. if not create default alpha with warning.
+    # Prefer a WCS-derived radial direction so partial frames keep the correct
+    # solar-center geometry. The north-referenced image-center fallback keeps
+    # legacy/non-solar WCS inputs usable, but warns because the result is only
+    # an approximation.
     img_shape = _determine_image_shape(input_data)
     keys = list(input_data.keys())
     wcs = input_data[keys[0]].wcs
@@ -249,11 +252,11 @@ def add_alpha(input_data: NDCollection) -> NDCollection:
     if len(img_shape) == 2:  # it's an image and not just an array
         try:
             alpha = radial_from_wcs(wcs, img_shape)
-        except Exception as err:  # pragma: no cover - best-effort fallback
+        except (AttributeError, KeyError, TypeError, ValueError) as err:  # pragma: no cover - best-effort fallback
             alpha = radial_north(img_shape)
             try:
                 alpha = wrap_pm_pi(alpha + solnorth_from_wcs(wcs, img_shape).to(u.radian))
-            except Exception:
+            except (AttributeError, KeyError, TypeError, ValueError):
                 pass
             warnings.warn(
                 f"Falling back to image-centered alpha approximation because WCS-based solar-center calculation failed: {err}",

--- a/solpolpy/core.py
+++ b/solpolpy/core.py
@@ -4,10 +4,11 @@ import warnings
 
 import astropy.units as u
 import networkx as nx
+import numpy as np
 from ndcube import NDCollection, NDCube
 
 from solpolpy.alpha import radial_from_wcs, radial_north
-from solpolpy.constants import STEREOA_REFERENCE_ANGLE, STEREOB_REFERENCE_ANGLE
+from solpolpy.constants import ASPIICS_REFERENCE_ANGLE, LASCO_REFERENCE_ANGLE, STEREOA_REFERENCE_ANGLE, STEREOB_REFERENCE_ANGLE
 from solpolpy.errors import UnsupportedTransformationError
 from solpolpy.instruments import load_data
 from solpolpy.physics import wrap_pm_pi
@@ -89,15 +90,40 @@ def resolve(input_data: list[str] | NDCollection,
 def determine_reference_angle(input_collection: NDCollection) -> u.degree:
     """Get the instrument specific offset angle."""
     first_key = next(iter(input_collection.keys()))
-    match input_collection[first_key].meta.get("OBSRVTRY", "BLANK"):
+    meta = input_collection[first_key].meta
+    match meta.get("OBSRVTRY", "BLANK"):
         case "STEREO_A":
             reference_angle = STEREOA_REFERENCE_ANGLE
         case "STEREO_B":
             reference_angle = STEREOB_REFERENCE_ANGLE
         case _:
-            reference_angle = 0 * u.degree
+            if _is_aspiics(input_collection):
+                reference_angle = _aspiics_reference_angle(input_collection)
+            elif meta.get("INSTRUME") == "LASCO" or meta.get("TELESCOP") == "SOHO":
+                reference_angle = LASCO_REFERENCE_ANGLE
+            else:
+                reference_angle = 0 * u.degree
 
     return reference_angle
+
+
+def _is_aspiics(input_collection: NDCollection) -> bool:
+    first_key = next(iter(input_collection.keys()))
+    meta = input_collection[first_key].meta
+    return meta.get("OBSRVTRY") == "PROBA-3" or meta.get("INSTRUME") == "ASPIICS"
+
+
+def _aspiics_reference_angle(input_collection: NDCollection) -> u.degree:
+    """Return the ASPIICS +x-referenced polarizer angle offset."""
+    first_key = next(iter(input_collection.keys()))
+    cube = input_collection[first_key]
+    return ASPIICS_REFERENCE_ANGLE - solnorth_from_wcs(cube.wcs, cube.data.shape)
+
+
+def _uses_stereo_alpha_orientation(input_collection: NDCollection) -> bool:
+    """Return whether WCS alpha should use SECCHI/COR2 row orientation."""
+    first_key = next(iter(input_collection.keys()))
+    return input_collection[first_key].meta.get("OBSRVTRY") in {"STEREO_A", "STEREO_B"}
 
 
 def determine_input_kind(input_data: NDCollection) -> System:
@@ -252,6 +278,8 @@ def add_alpha(input_data: NDCollection) -> NDCollection:
     if len(img_shape) == 2:  # it's an image and not just an array
         try:
             alpha = radial_from_wcs(wcs, img_shape)
+            if _uses_stereo_alpha_orientation(input_data):
+                alpha = np.flipud(alpha)
         except (AttributeError, KeyError, TypeError, ValueError) as err:  # pragma: no cover - best-effort fallback
             alpha = radial_north(img_shape)
             try:

--- a/solpolpy/core.py
+++ b/solpolpy/core.py
@@ -8,7 +8,12 @@ import numpy as np
 from ndcube import NDCollection, NDCube
 
 from solpolpy.alpha import radial_from_wcs, radial_north
-from solpolpy.constants import ASPIICS_REFERENCE_ANGLE, LASCO_REFERENCE_ANGLE, STEREOA_REFERENCE_ANGLE, STEREOB_REFERENCE_ANGLE
+from solpolpy.constants import (
+    ASPIICS_REFERENCE_ANGLE,
+    LASCO_REFERENCE_ANGLE,
+    STEREOA_REFERENCE_ANGLE,
+    STEREOB_REFERENCE_ANGLE,
+)
 from solpolpy.errors import UnsupportedTransformationError
 from solpolpy.instruments import load_data
 from solpolpy.physics import wrap_pm_pi

--- a/solpolpy/core.py
+++ b/solpolpy/core.py
@@ -258,17 +258,25 @@ def _determine_image_shape(input_collection: NDCollection) -> tuple[int, int]:
 
 
 def add_alpha(input_data: NDCollection) -> NDCollection:
-    """Adds an alpha array to an image NDCollection.
+    """Add an alpha angle field to an image NDCollection.
 
     Parameters
     ----------
     input_data : NDCollection
-        dataset to append alpha to
+        Dataset to append alpha to.
 
     Returns
     -------
     NDCollection
-        dataset with alpha array appended
+        Dataset with an ``alpha`` cube appended.
+
+    Notes
+    -----
+    ``alpha`` is the per-pixel angle field used by the polarization transforms.
+    It is referenced to solar north with north = 0 and counterclockwise-positive
+    rotation. When the WCS contains usable solar coordinates, the alpha field is
+    constructed from that WCS so partial-frame images inherit the correct subset
+    of the larger solar-centered geometry.
 
     """
     # Prefer a WCS-derived radial direction so partial frames keep the correct
@@ -288,11 +296,14 @@ def add_alpha(input_data: NDCollection) -> NDCollection:
         except (AttributeError, KeyError, TypeError, ValueError) as err:  # pragma: no cover - best-effort fallback
             alpha = radial_north(img_shape)
             try:
-                alpha = wrap_pm_pi(alpha + solnorth_from_wcs(wcs, img_shape).to(u.radian))
+                # ``radial_north`` is already north-referenced; subtract the
+                # WCS north rotation to express the same radial field in the
+                # image frame used by the polarizer equations.
+                alpha = wrap_pm_pi(alpha - solnorth_from_wcs(wcs, img_shape).to(u.radian))
             except (AttributeError, KeyError, TypeError, ValueError):
                 pass
             warnings.warn(
-                f"Falling back to image-centered alpha approximation because WCS-based solar-center calculation failed: {err}",
+                f"Falling back to an image-centered alpha approximation because WCS-based alpha construction failed: {err}",
                 stacklevel=2,
             )
     else:

--- a/solpolpy/core.py
+++ b/solpolpy/core.py
@@ -1,15 +1,18 @@
 """Core transformation functions for solpolpy."""
 import typing as t
+import warnings
 
 import astropy.units as u
 import networkx as nx
 from ndcube import NDCollection, NDCube
 
-from solpolpy.alpha import radial_north
+from solpolpy.alpha import radial_from_wcs, radial_north
 from solpolpy.constants import STEREOA_REFERENCE_ANGLE, STEREOB_REFERENCE_ANGLE
 from solpolpy.errors import UnsupportedTransformationError
 from solpolpy.instruments import load_data
+from solpolpy.physics import wrap_pm_pi
 from solpolpy.transforms import SYSTEM_REQUIRED_KEYS, System, transform_graph
+from solpolpy.util import solnorth_from_wcs
 
 
 @u.quantity_input
@@ -66,10 +69,10 @@ def resolve(input_data: list[str] | NDCollection,
     transform_path = get_transform_path(input_kind, out_system)
     equation = get_transform_equation(transform_path)
 
-    if getattr(equation, "uses_out_angles", False) and out_angles is None:
+    if getattr(equation, "requires_out_angles", False) and out_angles is None:
         raise ValueError("Out angles must be specified for this transform.")
 
-    if getattr(equation, "uses_in_angles", False) and in_angles is None:
+    if getattr(equation, "requires_in_angles", False) and in_angles is None:
         raise ValueError("In angles must be specified for this transform.")
 
     if requires_alpha(equation) and "alpha" not in input_keys:
@@ -130,7 +133,7 @@ def determine_input_kind(input_data: NDCollection) -> System:
             return valid_kind
     try:
         input_keys_quantities = [u.Quantity(key) for key in input_keys]
-    except TypeError:
+    except (TypeError, ValueError):
         pass
     else:
         if all(u.get_physical_type(q) == "angle" for q in input_keys_quantities):
@@ -244,7 +247,18 @@ def add_alpha(input_data: NDCollection) -> NDCollection:
     meta = input_data[keys[0]].meta
 
     if len(img_shape) == 2:  # it's an image and not just an array
-        alpha = radial_north(img_shape)
+        try:
+            alpha = radial_from_wcs(wcs, img_shape)
+        except Exception as err:  # pragma: no cover - best-effort fallback
+            alpha = radial_north(img_shape)
+            try:
+                alpha = wrap_pm_pi(alpha + solnorth_from_wcs(wcs, img_shape).to(u.radian))
+            except Exception:
+                pass
+            warnings.warn(
+                f"Falling back to image-centered alpha approximation because WCS-based solar-center calculation failed: {err}",
+                stacklevel=2,
+            )
     else:
         msg = f"Data must be an image with 2 dimensions, found {len(img_shape)}."
         raise ValueError(msg)
@@ -276,6 +290,9 @@ def _compose2(f: t.Callable, g: t.Callable) -> t.Callable:
 
     out.uses_alpha = getattr(f, "uses_alpha", False) or getattr(g, "uses_alpha", False)
     out.uses_out_angles = getattr(f, "uses_out_angles", False) or getattr(g, "uses_out_angles", False)
+    out.uses_in_angles = getattr(f, "uses_in_angles", False) or getattr(g, "uses_in_angles", False)
+    out.requires_out_angles = getattr(f, "requires_out_angles", False) or getattr(g, "requires_out_angles", False)
+    out.requires_in_angles = getattr(f, "requires_in_angles", False) or getattr(g, "requires_in_angles", False)
 
     return out
 

--- a/solpolpy/instruments.py
+++ b/solpolpy/instruments.py
@@ -110,10 +110,11 @@ def construct_mask(inner_radius: float,
         (those with radius less than `inner_radius` or greater than `outer_radius`) as True
 
     """
-    xx, yy = np.ogrid[0:shape[0], 0:shape[1]]
+    yy, xx = np.ogrid[0:shape[0], 0:shape[1]]
+    radius_sq = (xx - center_x) ** 2 + (yy - center_y) ** 2
     mask = np.zeros(shape, dtype=bool)
-    mask[(xx - center_x) ** 2 + (yy - center_y) ** 2 < inner_radius] = True
-    mask[(xx - center_x) ** 2 + (yy - center_y) ** 2 > outer_radius] = True
+    mask[radius_sq < inner_radius] = True
+    mask[radius_sq > outer_radius] = True
     return mask
 
 
@@ -164,7 +165,6 @@ def get_instrument_mask(header: fits.Header) -> np.ndarray:
         msg = "The data in this file is not formatted according to a known instrument."
         raise UnsupportedInstrumentError(msg)
 
-    y_array = [(j_step - center_y) / R_sun for j_step in range(y_shape)]
-    outer_edge = np.max(y_array) * R_sun
+    outer_edge = min(center_x, center_y, x_shape - center_x - 1, y_shape - center_y - 1)
 
     return construct_mask((radius * R_sun) ** 2, outer_edge ** 2, center_x, center_y, (x_shape, y_shape))

--- a/solpolpy/instruments.py
+++ b/solpolpy/instruments.py
@@ -70,12 +70,14 @@ def load_data(path_list: list[str],
                 mask = np.zeros(hdul[hdu_index].data.shape, dtype=bool)
 
             angle = get_data_angle(hdul[hdu_index].header)
+            meta = dict(hdul[hdu_index].header)
+            meta["POLAR"] = angle
 
             data_out.append((str(angle),
                              NDCube(hdul[hdu_index].data,
                                     mask=mask,
                                     wcs=wcs,
-                                    meta=dict(hdul[hdu_index].header))))
+                                    meta=meta)))
 
     return NDCollection(data_out, meta={}, aligned_axes="all")
 

--- a/solpolpy/physics/__init__.py
+++ b/solpolpy/physics/__init__.py
@@ -1,0 +1,37 @@
+"""Shared physics helpers for polarization transforms."""
+
+from solpolpy.physics.collections import (
+    clone_meta,
+    combine_mask,
+    data_keys,
+    stack_data,
+    template_cube,
+)
+from solpolpy.physics.polarization import (
+    MZP_ANGLES,
+    angle_difference_radians,
+    as_angle,
+    bp3_from_analyzer_brightness,
+    bp3_to_analyzer_brightness,
+    project_three_polarizer_brightness,
+    solve_three_polarizer_brightness,
+    wrap_linear_polarization,
+    wrap_pm_pi,
+)
+
+__all__ = [
+    "MZP_ANGLES",
+    "angle_difference_radians",
+    "as_angle",
+    "bp3_from_analyzer_brightness",
+    "bp3_to_analyzer_brightness",
+    "clone_meta",
+    "combine_mask",
+    "data_keys",
+    "project_three_polarizer_brightness",
+    "solve_three_polarizer_brightness",
+    "stack_data",
+    "template_cube",
+    "wrap_linear_polarization",
+    "wrap_pm_pi",
+]

--- a/solpolpy/physics/__init__.py
+++ b/solpolpy/physics/__init__.py
@@ -1,12 +1,12 @@
 """Shared physics helpers for polarization transforms."""
 
-from solpolpy.physics.collections import clone_meta, combine_mask, data_keys, stack_data, template_cube
+from solpolpy.physics.collections import clone_meta, get_data_keys, get_template_cube, stack_data
 from solpolpy.physics.polarization import (
     MZP_ANGLES,
-    angle_difference_radians,
     as_angle,
     bp3_from_analyzer_brightness,
     bp3_to_analyzer_brightness,
+    calculate_angle_difference,
     project_three_polarizer_brightness,
     solve_three_polarizer_brightness,
     wrap_linear_polarization,
@@ -15,17 +15,16 @@ from solpolpy.physics.polarization import (
 
 __all__ = [
     "MZP_ANGLES",
-    "angle_difference_radians",
     "as_angle",
     "bp3_from_analyzer_brightness",
     "bp3_to_analyzer_brightness",
+    "calculate_angle_difference",
     "clone_meta",
-    "combine_mask",
-    "data_keys",
+    "get_data_keys",
+    "get_template_cube",
     "project_three_polarizer_brightness",
     "solve_three_polarizer_brightness",
     "stack_data",
-    "template_cube",
     "wrap_linear_polarization",
     "wrap_pm_pi",
 ]

--- a/solpolpy/physics/__init__.py
+++ b/solpolpy/physics/__init__.py
@@ -4,9 +4,9 @@ from solpolpy.physics.collections import clone_meta, get_data_keys, get_template
 from solpolpy.physics.polarization import (
     MZP_ANGLES,
     as_angle,
-    bp3_from_analyzer_brightness,
-    bp3_to_analyzer_brightness,
     calculate_angle_difference,
+    bp3_from_polarizer_brightness,
+    bp3_to_polarizer_brightness,
     project_three_polarizer_brightness,
     solve_three_polarizer_brightness,
     wrap_linear_polarization,
@@ -16,9 +16,9 @@ from solpolpy.physics.polarization import (
 __all__ = [
     "MZP_ANGLES",
     "as_angle",
-    "bp3_from_analyzer_brightness",
-    "bp3_to_analyzer_brightness",
     "calculate_angle_difference",
+    "bp3_from_polarizer_brightness",
+    "bp3_to_polarizer_brightness",
     "clone_meta",
     "get_data_keys",
     "get_template_cube",

--- a/solpolpy/physics/__init__.py
+++ b/solpolpy/physics/__init__.py
@@ -1,12 +1,6 @@
 """Shared physics helpers for polarization transforms."""
 
-from solpolpy.physics.collections import (
-    clone_meta,
-    combine_mask,
-    data_keys,
-    stack_data,
-    template_cube,
-)
+from solpolpy.physics.collections import clone_meta, combine_mask, data_keys, stack_data, template_cube
 from solpolpy.physics.polarization import (
     MZP_ANGLES,
     angle_difference_radians,

--- a/solpolpy/physics/__init__.py
+++ b/solpolpy/physics/__init__.py
@@ -4,9 +4,9 @@ from solpolpy.physics.collections import clone_meta, get_data_keys, get_template
 from solpolpy.physics.polarization import (
     MZP_ANGLES,
     as_angle,
-    calculate_angle_difference,
     bp3_from_polarizer_brightness,
     bp3_to_polarizer_brightness,
+    calculate_angle_difference,
     project_three_polarizer_brightness,
     solve_three_polarizer_brightness,
     wrap_linear_polarization,

--- a/solpolpy/physics/collections.py
+++ b/solpolpy/physics/collections.py
@@ -1,0 +1,38 @@
+"""Helpers for building and reading NDCollection-based transform inputs."""
+
+from __future__ import annotations
+
+import copy
+
+from ndcube import NDCollection
+
+from solpolpy.util import combine_all_collection_masks
+
+
+def data_keys(collection: NDCollection) -> list[str]:
+    """Return collection keys excluding the auxiliary alpha cube."""
+    return [key for key in collection.keys() if key != "alpha"]
+
+
+def template_cube(collection: NDCollection, preferred_key: str | None = None):
+    """Return the cube that should be used as metadata/WCS template."""
+    if preferred_key is not None and preferred_key in collection:
+        return collection[preferred_key]
+    return collection[data_keys(collection)[0]]
+
+
+def stack_data(collection: NDCollection, keys: list[str]) -> list:
+    """Stack raw cube data in key order."""
+    return [collection[key].data for key in keys]
+
+
+def clone_meta(cube, **updates):
+    """Deep copy a cube metadata mapping and update it."""
+    meta = copy.deepcopy(cube.meta)
+    meta.update(updates)
+    return meta
+
+
+def combine_mask(collection: NDCollection):
+    """Combine masks across all data cubes in a collection."""
+    return combine_all_collection_masks(collection)

--- a/solpolpy/physics/collections.py
+++ b/solpolpy/physics/collections.py
@@ -3,36 +3,30 @@
 from __future__ import annotations
 
 import copy
+from typing import Any
 
 from ndcube import NDCollection
 
-from solpolpy.util import combine_all_collection_masks
 
-
-def data_keys(collection: NDCollection) -> list[str]:
+def get_data_keys(collection: NDCollection) -> list[str]:
     """Return collection keys excluding the auxiliary alpha cube."""
     return [key for key in collection.keys() if key != "alpha"]
 
 
-def template_cube(collection: NDCollection, preferred_key: str | None = None):
-    """Return the cube that should be used as metadata/WCS template."""
+def get_template_cube(collection: NDCollection, preferred_key: str | None = None) -> Any:
+    """Return the cube that should be used as the metadata and WCS template."""
     if preferred_key is not None and preferred_key in collection:
         return collection[preferred_key]
-    return collection[data_keys(collection)[0]]
+    return collection[get_data_keys(collection)[0]]
 
 
-def stack_data(collection: NDCollection, keys: list[str]) -> list:
+def stack_data(collection: NDCollection, keys: list[str]) -> list[Any]:
     """Stack raw cube data in key order."""
     return [collection[key].data for key in keys]
 
 
-def clone_meta(cube, **updates):
+def clone_meta(cube: Any, **updates: Any) -> Any:
     """Deep copy a cube metadata mapping and update it."""
     meta = copy.deepcopy(cube.meta)
     meta.update(updates)
     return meta
-
-
-def combine_mask(collection: NDCollection):
-    """Combine masks across all data cubes in a collection."""
-    return combine_all_collection_masks(collection)

--- a/solpolpy/physics/collections.py
+++ b/solpolpy/physics/collections.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+import astropy.units as u
 from ndcube import NDCollection
 
 
@@ -27,6 +28,23 @@ def stack_data(collection: NDCollection, keys: list[str]) -> list[Any]:
 
 def clone_meta(cube: Any, **updates: Any) -> Any:
     """Deep copy a cube metadata mapping and update it."""
+    normalized_updates = {}
+    for key, value in updates.items():
+        if isinstance(value, u.Quantity):
+            normalized_updates[key] = value.value
+        else:
+            normalized_updates[key] = value
+
     meta = copy.deepcopy(cube.meta)
-    meta.update(updates)
+    if hasattr(meta, "update"):
+        meta.update(normalized_updates)
+        return meta
+
+    if hasattr(cube.meta, "to_fits_header"):
+        meta = cube.meta.to_fits_header(cube.wcs)
+        meta.update(normalized_updates)
+        return meta
+
+    meta = {key: copy.deepcopy(cube.meta[key]) for key in cube.meta.keys()}
+    meta.update(normalized_updates)
     return meta

--- a/solpolpy/physics/polarization.py
+++ b/solpolpy/physics/polarization.py
@@ -17,6 +17,8 @@ def as_angle(angles, default_unit: u.Unit = u.radian) -> u.Quantity:
     helper is intentionally more permissive than ``quantity_input`` because
     FITS metadata and older call sites can provide plain numeric angle values.
     """
+    if not isinstance(angles, u.Quantity) and hasattr(angles, "value"):
+        angles = angles.value
     quantity = u.Quantity(angles)
     if quantity.unit == u.dimensionless_unscaled:
         quantity = quantity * default_unit

--- a/solpolpy/physics/polarization.py
+++ b/solpolpy/physics/polarization.py
@@ -57,33 +57,33 @@ def _angle_difference_radians(target_angle: u.Quantity, source_angle: u.Quantity
     return calculate_angle_difference(as_angle(target_angle, u.radian), as_angle(source_angle, u.radian)).to_value(u.radian)
 
 
-def bp3_to_analyzer_brightness(
+def bp3_to_polarizer_brightness(
     B: np.ndarray,
     pB: np.ndarray,
     pBp: np.ndarray,
     alpha: u.Quantity,
-    analyzer_angles: u.Quantity,
+    polarizer_angles: u.Quantity,
 ) -> np.ndarray:
-    """Evaluate analyzer brightness at the requested analyzer angles."""
+    """Evaluate polarizer brightness at the requested polarizer angles."""
     angle_stack = []
-    for angle in u.Quantity(analyzer_angles):
+    for angle in u.Quantity(polarizer_angles):
         delta = _angle_difference_radians(angle, alpha)
         angle_stack.append(0.5 * (B - pB * np.cos(2 * delta) - pBp * np.sin(2 * delta)))
     return np.stack(angle_stack, axis=0)
 
 
-def bp3_from_analyzer_brightness(
+def bp3_from_polarizer_brightness(
     brightness_stack: np.ndarray,
-    analyzer_angles: u.Quantity,
+    polarizer_angles: u.Quantity,
     alpha: u.Quantity,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Recover B, pB, and pBp from analyzer brightness measurements."""
+    """Recover B, pB, and pBp from polarizer brightness measurements."""
     brightness_stack = np.asarray(brightness_stack)
     B = (2.0 / 3.0) * np.sum(brightness_stack, axis=0)
 
     cos_terms = []
     sin_terms = []
-    for brightness, angle in zip(brightness_stack, u.Quantity(analyzer_angles), strict=False):
+    for brightness, angle in zip(brightness_stack, u.Quantity(polarizer_angles), strict=False):
         delta = _angle_difference_radians(angle, alpha)
         cos_terms.append(brightness * np.cos(2 * delta))
         sin_terms.append(brightness * np.sin(2 * delta))
@@ -98,7 +98,7 @@ def _three_polarizer_matrix(
     target_angles: u.Quantity,
     reference_angle: u.Quantity = 0 * u.degree,
 ) -> np.ndarray:
-    """Return the Equation 44 projection matrix for three analyzer angles."""
+    """Return the Equation 44 projection matrix for three polarizer angles."""
     source = u.Quantity(source_angles)
     target = u.Quantity(target_angles)
     reference = _as_radians(reference_angle)
@@ -145,7 +145,7 @@ def project_three_polarizer_brightness(
     target_angles: u.Quantity,
     reference_angle: u.Quantity = 0 * u.degree,
 ) -> np.ndarray:
-    """Project three-polarizer brightness measurements onto new analyzer angles."""
+    """Project three-polarizer brightness measurements onto new polarizer angles."""
     projected = []
     reference = _as_radians(reference_angle)
 

--- a/solpolpy/physics/polarization.py
+++ b/solpolpy/physics/polarization.py
@@ -10,47 +10,73 @@ from solpolpy.errors import SolpolpyError
 MZP_ANGLES = np.array([-60.0, 0.0, 60.0]) * u.degree
 
 
-def as_angle(angles, default_unit=u.radian):
-    """Return an input as an angular quantity."""
+def as_angle(angles, default_unit: u.Unit = u.radian) -> u.Quantity:
+    """Return an input as an angular quantity.
+
+    Scalars and arrays without units are interpreted in ``default_unit``. This
+    helper is intentionally more permissive than ``quantity_input`` because
+    FITS metadata and older call sites can provide plain numeric angle values.
+    """
     quantity = u.Quantity(angles)
     if quantity.unit == u.dimensionless_unscaled:
         quantity = quantity * default_unit
     return quantity
 
 
-def wrap_pm_pi(angle):
+@u.quantity_input(angle=u.radian)
+def wrap_pm_pi(angle: u.Quantity):
     """Wrap an angle into [-pi, pi) or the unit-equivalent interval."""
-    quantity = as_angle(angle, default_unit=u.radian).to(u.radian)
+    input_unit = angle.unit
+    quantity = angle.to(u.radian)
     wrapped = (quantity + np.pi * u.radian) % (2 * np.pi * u.radian) - np.pi * u.radian
-    return wrapped.to(quantity.unit)
+    return wrapped.to(input_unit)
 
 
-def wrap_linear_polarization(angle):
+@u.quantity_input(angle=u.radian)
+def wrap_linear_polarization(angle: u.Quantity):
     """Wrap a linear-polarization axis angle into [-pi/2, pi/2)."""
-    quantity = as_angle(angle, default_unit=u.radian).to(u.radian)
+    input_unit = angle.unit
+    quantity = angle.to(u.radian)
     wrapped = (quantity + (np.pi / 2) * u.radian) % (np.pi * u.radian) - (np.pi / 2) * u.radian
-    return wrapped.to(quantity.unit)
+    return wrapped.to(input_unit)
 
 
-def angle_difference_radians(target_angle, source_angle):
-    """Return a wrapped target-source angle difference in radians."""
-    return wrap_pm_pi(as_angle(target_angle, u.radian) - as_angle(source_angle, u.radian)).to_value(u.radian)
+@u.quantity_input(target_angle=u.radian, source_angle=u.radian)
+def calculate_angle_difference(target_angle: u.Quantity, source_angle: u.Quantity):
+    """Return the wrapped ``target_angle - source_angle`` difference."""
+    return wrap_pm_pi(target_angle - source_angle)
 
 
-def _as_radians(angles):
+def _as_radians(angles: u.Quantity) -> np.ndarray:
+    """Return angle values in radians for numeric trigonometric operations."""
     return as_angle(angles, u.radian).to_value(u.radian)
 
 
-def bp3_to_analyzer_brightness(B, pB, pBp, alpha, analyzer_angles):
+def _angle_difference_radians(target_angle: u.Quantity, source_angle: u.Quantity) -> np.ndarray:
+    """Return wrapped angle-difference values in radians."""
+    return calculate_angle_difference(as_angle(target_angle, u.radian), as_angle(source_angle, u.radian)).to_value(u.radian)
+
+
+def bp3_to_analyzer_brightness(
+    B: np.ndarray,
+    pB: np.ndarray,
+    pBp: np.ndarray,
+    alpha: u.Quantity,
+    analyzer_angles: u.Quantity,
+) -> np.ndarray:
     """Evaluate analyzer brightness at the requested analyzer angles."""
     angle_stack = []
     for angle in u.Quantity(analyzer_angles):
-        delta = angle_difference_radians(angle, alpha)
+        delta = _angle_difference_radians(angle, alpha)
         angle_stack.append(0.5 * (B - pB * np.cos(2 * delta) - pBp * np.sin(2 * delta)))
     return np.stack(angle_stack, axis=0)
 
 
-def bp3_from_analyzer_brightness(brightness_stack, analyzer_angles, alpha):
+def bp3_from_analyzer_brightness(
+    brightness_stack: np.ndarray,
+    analyzer_angles: u.Quantity,
+    alpha: u.Quantity,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Recover B, pB, and pBp from analyzer brightness measurements."""
     brightness_stack = np.asarray(brightness_stack)
     B = (2.0 / 3.0) * np.sum(brightness_stack, axis=0)
@@ -58,7 +84,7 @@ def bp3_from_analyzer_brightness(brightness_stack, analyzer_angles, alpha):
     cos_terms = []
     sin_terms = []
     for brightness, angle in zip(brightness_stack, u.Quantity(analyzer_angles), strict=False):
-        delta = angle_difference_radians(angle, alpha)
+        delta = _angle_difference_radians(angle, alpha)
         cos_terms.append(brightness * np.cos(2 * delta))
         sin_terms.append(brightness * np.sin(2 * delta))
 
@@ -67,7 +93,12 @@ def bp3_from_analyzer_brightness(brightness_stack, analyzer_angles, alpha):
     return B, pB, pBp
 
 
-def _three_polarizer_matrix(source_angles, target_angles, reference_angle=0 * u.degree):
+def _three_polarizer_matrix(
+    source_angles: u.Quantity,
+    target_angles: u.Quantity,
+    reference_angle: u.Quantity = 0 * u.degree,
+) -> np.ndarray:
+    """Return the Equation 44 projection matrix for three analyzer angles."""
     source = u.Quantity(source_angles)
     target = u.Quantity(target_angles)
     reference = _as_radians(reference_angle)
@@ -76,18 +107,26 @@ def _three_polarizer_matrix(source_angles, target_angles, reference_angle=0 * u.
     for source_angle in source:
         row = []
         for target_angle in target:
-            delta = angle_difference_radians(source_angle, target_angle) - reference
+            delta = _angle_difference_radians(source_angle, target_angle) - reference
             row.append((4.0 * np.cos(delta) ** 2 - 1.0) / 3.0)
         rows.append(np.stack(row, axis=0))
     return np.stack(rows, axis=0)
 
 
-def solve_three_polarizer_brightness(observed_brightness, observed_angles, solved_angles, reference_angle=0 * u.degree):
+def solve_three_polarizer_brightness(
+    observed_brightness: np.ndarray,
+    observed_angles: u.Quantity,
+    solved_angles: u.Quantity,
+    reference_angle: u.Quantity = 0 * u.degree,
+) -> np.ndarray:
     """Solve Equation 44-style systems for the requested output basis."""
     matrix = _three_polarizer_matrix(observed_angles, solved_angles, reference_angle=reference_angle)
     rhs = np.moveaxis(np.asarray(observed_brightness), 0, -1)[..., None]
 
     if matrix.ndim > 2:
+        # Pixelwise reference angles produce a matrix per pixel. Move the
+        # matrix axes behind the image axes so numpy can solve all pixels at
+        # once with batched matrix multiplication.
         matrix = np.moveaxis(matrix, (0, 1), (-2, -1))
 
     try:
@@ -100,7 +139,12 @@ def solve_three_polarizer_brightness(observed_brightness, observed_angles, solve
     return np.moveaxis(solution, -1, 0)
 
 
-def project_three_polarizer_brightness(source_brightness, source_angles, target_angles, reference_angle=0 * u.degree):
+def project_three_polarizer_brightness(
+    source_brightness: np.ndarray,
+    source_angles: u.Quantity,
+    target_angles: u.Quantity,
+    reference_angle: u.Quantity = 0 * u.degree,
+) -> np.ndarray:
     """Project three-polarizer brightness measurements onto new analyzer angles."""
     projected = []
     reference = _as_radians(reference_angle)
@@ -108,7 +152,7 @@ def project_three_polarizer_brightness(source_brightness, source_angles, target_
     for target_angle in u.Quantity(target_angles):
         value = 0.0
         for brightness, source_angle in zip(source_brightness, u.Quantity(source_angles), strict=False):
-            delta = angle_difference_radians(target_angle, source_angle) - reference
+            delta = _angle_difference_radians(target_angle, source_angle) - reference
             value = value + brightness * ((4.0 * np.cos(delta) ** 2 - 1.0) / 3.0)
         projected.append(value)
 

--- a/solpolpy/physics/polarization.py
+++ b/solpolpy/physics/polarization.py
@@ -1,0 +1,115 @@
+"""Equation-based helpers for linear polarization transforms."""
+
+from __future__ import annotations
+
+import astropy.units as u
+import numpy as np
+
+from solpolpy.errors import SolpolpyError
+
+MZP_ANGLES = np.array([-60.0, 0.0, 60.0]) * u.degree
+
+
+def as_angle(angles, default_unit=u.radian):
+    """Return an input as an angular quantity."""
+    quantity = u.Quantity(angles)
+    if quantity.unit == u.dimensionless_unscaled:
+        quantity = quantity * default_unit
+    return quantity
+
+
+def wrap_pm_pi(angle):
+    """Wrap an angle into [-pi, pi) or the unit-equivalent interval."""
+    quantity = as_angle(angle, default_unit=u.radian).to(u.radian)
+    wrapped = (quantity + np.pi * u.radian) % (2 * np.pi * u.radian) - np.pi * u.radian
+    return wrapped.to(quantity.unit)
+
+
+def wrap_linear_polarization(angle):
+    """Wrap a linear-polarization axis angle into [-pi/2, pi/2)."""
+    quantity = as_angle(angle, default_unit=u.radian).to(u.radian)
+    wrapped = (quantity + (np.pi / 2) * u.radian) % (np.pi * u.radian) - (np.pi / 2) * u.radian
+    return wrapped.to(quantity.unit)
+
+
+def angle_difference_radians(target_angle, source_angle):
+    """Return a wrapped target-source angle difference in radians."""
+    return wrap_pm_pi(as_angle(target_angle, u.radian) - as_angle(source_angle, u.radian)).to_value(u.radian)
+
+
+def _as_radians(angles):
+    return as_angle(angles, u.radian).to_value(u.radian)
+
+
+def bp3_to_analyzer_brightness(B, pB, pBp, alpha, analyzer_angles):
+    """Evaluate analyzer brightness at the requested analyzer angles."""
+    angle_stack = []
+    for angle in u.Quantity(analyzer_angles):
+        delta = angle_difference_radians(angle, alpha)
+        angle_stack.append(0.5 * (B - pB * np.cos(2 * delta) - pBp * np.sin(2 * delta)))
+    return np.stack(angle_stack, axis=0)
+
+
+def bp3_from_analyzer_brightness(brightness_stack, analyzer_angles, alpha):
+    """Recover B, pB, and pBp from analyzer brightness measurements."""
+    brightness_stack = np.asarray(brightness_stack)
+    B = (2.0 / 3.0) * np.sum(brightness_stack, axis=0)
+
+    cos_terms = []
+    sin_terms = []
+    for brightness, angle in zip(brightness_stack, u.Quantity(analyzer_angles), strict=False):
+        delta = angle_difference_radians(angle, alpha)
+        cos_terms.append(brightness * np.cos(2 * delta))
+        sin_terms.append(brightness * np.sin(2 * delta))
+
+    pB = (-4.0 / 3.0) * np.sum(cos_terms, axis=0)
+    pBp = (-4.0 / 3.0) * np.sum(sin_terms, axis=0)
+    return B, pB, pBp
+
+
+def _three_polarizer_matrix(source_angles, target_angles, reference_angle=0 * u.degree):
+    source = u.Quantity(source_angles)
+    target = u.Quantity(target_angles)
+    reference = _as_radians(reference_angle)
+
+    rows = []
+    for source_angle in source:
+        row = []
+        for target_angle in target:
+            delta = angle_difference_radians(source_angle, target_angle) - reference
+            row.append((4.0 * np.cos(delta) ** 2 - 1.0) / 3.0)
+        rows.append(np.stack(row, axis=0))
+    return np.stack(rows, axis=0)
+
+
+def solve_three_polarizer_brightness(observed_brightness, observed_angles, solved_angles, reference_angle=0 * u.degree):
+    """Solve Equation 44-style systems for the requested output basis."""
+    matrix = _three_polarizer_matrix(observed_angles, solved_angles, reference_angle=reference_angle)
+    rhs = np.moveaxis(np.asarray(observed_brightness), 0, -1)[..., None]
+
+    if matrix.ndim > 2:
+        matrix = np.moveaxis(matrix, (0, 1), (-2, -1))
+
+    try:
+        solution = np.matmul(np.linalg.inv(matrix), rhs)[..., 0]
+    except np.linalg.LinAlgError as err:
+        if "Singular matrix" in str(err):
+            raise SolpolpyError("Conversion matrix is degenerate") from err
+        raise
+
+    return np.moveaxis(solution, -1, 0)
+
+
+def project_three_polarizer_brightness(source_brightness, source_angles, target_angles, reference_angle=0 * u.degree):
+    """Project three-polarizer brightness measurements onto new analyzer angles."""
+    projected = []
+    reference = _as_radians(reference_angle)
+
+    for target_angle in u.Quantity(target_angles):
+        value = 0.0
+        for brightness, source_angle in zip(source_brightness, u.Quantity(source_angles), strict=False):
+            delta = angle_difference_radians(target_angle, source_angle) - reference
+            value = value + brightness * ((4.0 * np.cos(delta) ** 2 - 1.0) / 3.0)
+        projected.append(value)
+
+    return np.stack(projected, axis=0)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -1,11 +1,7 @@
-"""Polarizer functions for solpolpy.
-Found in:
-DeForest, C. E., Seaton, D. B., & West, M. J. (2022).
-Three-polarizer Treatment of Linear Polarization in Coronagraphs and Heliospheric Imagers.
-The Astrophysical Journal, 927(1), 98.
-"""
+"""Polarizer functions for solpolpy."""
+
 import sys
-import copy
+import warnings
 from enum import StrEnum
 from inspect import signature, getmembers, isfunction
 
@@ -14,8 +10,23 @@ import networkx as nx
 import numpy as np
 from ndcube import NDCollection, NDCube
 
-from solpolpy.errors import InvalidDataError, MissingAlphaError, SolpolpyError
-from solpolpy.util import combine_all_collection_masks, compute_lats, solnorth_from_wcs
+from solpolpy.errors import InvalidDataError, MissingAlphaError
+from solpolpy.physics import (
+    MZP_ANGLES,
+    angle_difference_radians,
+    as_angle,
+    bp3_from_analyzer_brightness,
+    bp3_to_analyzer_brightness,
+    clone_meta,
+    combine_mask,
+    data_keys,
+    project_three_polarizer_brightness,
+    solve_three_polarizer_brightness,
+    stack_data,
+    template_cube,
+    wrap_linear_polarization,
+)
+from solpolpy.util import compute_lats, solnorth_from_wcs
 
 System = StrEnum("System", ["bpb", "npol", "stokes", "mzpsolar", "mzpinstru", "btbr", "bthp", "fourpol", "bp3"])
 SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},
@@ -33,15 +44,19 @@ SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},
 def transform(source_system, target_system, use_alpha):
     """Decorator for transforms."""
     def decorator(transform_function):
-        transform_parameters = signature(transform_function).parameters
+        transform_signature = signature(transform_function)
+        transform_parameters = transform_signature.parameters
         uses_out_angles = "out_angles" in transform_parameters
         uses_in_angles = "in_angles" in transform_parameters
+        requires_out_angles = uses_out_angles and transform_parameters["out_angles"].default is transform_signature.empty
+        requires_in_angles = uses_in_angles and transform_parameters["in_angles"].default is transform_signature.empty
 
         def wrapper(input_collection, *args, **kwargs):
-            if uses_out_angles and "out_angles" not in transform_parameters:
+            bound_args = transform_signature.bind_partial(input_collection, *args, **kwargs)
+            if requires_out_angles and bound_args.arguments.get("out_angles") is None:
                 msg = "Out angles is expected but not provided for this function"
                 raise InvalidDataError(msg)
-            if uses_in_angles and "in_angles" not in transform_parameters:
+            if requires_in_angles and bound_args.arguments.get("in_angles") is None:
                 msg = "In angles is expected but not provided for this function"
                 raise InvalidDataError(msg)
             if use_alpha and "alpha" not in input_collection:
@@ -56,68 +71,138 @@ def transform(source_system, target_system, use_alpha):
 
         wrapper.uses_out_angles = uses_out_angles
         wrapper.uses_in_angles = uses_in_angles
+        wrapper.requires_out_angles = requires_out_angles
+        wrapper.requires_in_angles = requires_in_angles
         wrapper.uses_alpha = use_alpha
         wrapper.fcn = transform_function
         return wrapper
     return decorator
 
 
-@transform(System.npol, System.mzpsolar, use_alpha=False)
-@u.quantity_input
-def npol_to_mzpsolar(input_collection, in_angles: u.degree = None, reference_angle=0 * u.degree, **kwargs):
-    """
-    Notes
-    ------
-    Equation 44 in DeForest et al. 2022.
-    """
-    input_keys = list(input_collection.keys())
-    if in_angles is not None:
-        phi = in_angles
+def _alpha_data(collection: NDCollection):
+    return as_angle(collection["alpha"].data, u.radian).to(u.radian)
+
+
+def _collection_from_cubes(cubes):
+    return NDCollection(cubes, meta={}, aligned_axes="all")
+
+
+def _shared_polaroff(input_collection: NDCollection, keys):
+    offsets = []
+    for key in keys:
+        if key in input_collection and "POLAROFF" in input_collection[key].meta:
+            offsets.append(as_angle(input_collection[key].meta["POLAROFF"], u.degree))
+
+    if not offsets:
+        return None
+
+    first = offsets[0].to_value(u.degree)
+    if all(np.allclose(offset.to_value(u.degree), first) for offset in offsets[1:]):
+        return offsets[0]
+
+    warnings.warn(
+        "Input collection contains mixed POLAROFF values; reduced output metadata cannot preserve per-channel offsets.",
+        stacklevel=2,
+    )
+    return None
+
+
+def _meta_with_shared_polaroff(cube, shared_polaroff, **updates):
+    meta = clone_meta(cube, **updates)
+    if shared_polaroff is None:
+        meta.pop("POLAROFF", None)
     else:
-        phi = [input_collection[key].meta['POLAR'] for key in input_keys if key != 'alpha'] * u.degree
+        meta["POLAROFF"] = shared_polaroff
+    return meta
 
-    mzp_angles = [-60, 0, 60] * u.degree  # theta angle in Eq 44
 
-    data_shape = input_collection[input_keys[0]].data.shape
-    data_npol = np.zeros([data_shape[0], data_shape[1], 3, 1])
+def _warn_if_information_is_lost(pBp, B, context):
+    with np.errstate(divide="ignore", invalid="ignore"):
+        relative_pbp = np.abs(
+            np.divide(
+                pBp,
+                B,
+                out=np.zeros_like(np.asarray(pBp, dtype=float), dtype=float),
+                where=np.not_equal(B, 0),
+            )
+        )
 
-    conv_matrix = np.array([[(4 * np.cos(phi[j] - mzp_angles[i] - reference_angle) ** 2 - 1)
-                           for i in range(3)] for j in range(3)]) / 3
+    max_relative_pbp = np.nanmax(relative_pbp)
+    if max_relative_pbp > 1e-6:
+        warnings.warn(
+            (
+                f"{context} assumes pBp = 0, so roundtrip recovery will not be exact when the input carries "
+                f"nonzero pBp. max(|pBp/B|)={max_relative_pbp:.3%}"
+            ),
+            stacklevel=2,
+        )
 
-    for i, key in enumerate(key for key in input_keys if key != 'alpha'):
-        data_npol[:, :, i, 0] = input_collection[key].data
 
-    if conv_matrix.ndim > 2:
-        conv_matrix_pix = np.moveaxis(conv_matrix, (0, 1), (-2, -1))  # (ny, nx, 3, 3) type; moving the first two axes to the end
-    else:
-        conv_matrix_pix = conv_matrix
-    try:
-        conv_matrix_inv = np.linalg.inv(conv_matrix_pix)
-    except np.linalg.LinAlgError as err:
-        if "Singular matrix" in str(err):
-            raise SolpolpyError("Conversion matrix is degenerate")
+def _append_alpha(cubes, input_collection: NDCollection, mask=None):
+    if "alpha" not in input_collection:
+        return cubes
+    alpha_cube = input_collection["alpha"]
+    cubes.append(
+        (
+            "alpha",
+            NDCube(
+                _alpha_data(input_collection),
+                wcs=alpha_cube.wcs,
+                mask=mask if mask is not None else alpha_cube.mask,
+                meta=alpha_cube.meta,
+            ),
+        )
+    )
+    return cubes
 
-    data_mzp_solar = np.matmul(conv_matrix_inv, data_npol)
 
-    metas = [copy.copy(input_collection[input_keys[0]].meta) for _ in range(3)]
+def _mzp_cubes_from_stack(data_stack, input_collection: NDCollection, mask=None, preferred_key: str | None = None):
+    cube_template = template_cube(input_collection, preferred_key=preferred_key)
+    shared_polaroff = _shared_polaroff(input_collection, data_keys(input_collection))
+    cubes = []
+    for key, angle, data in zip(["M", "Z", "P"], MZP_ANGLES, data_stack, strict=False):
+        cubes.append(
+            (
+                key,
+                NDCube(
+                    data,
+                    wcs=cube_template.wcs,
+                    mask=mask,
+                    meta=_meta_with_shared_polaroff(cube_template, shared_polaroff, POLAR=angle, POLARREF="Solar"),
+                ),
+            )
+        )
+    return cubes
 
-    for meta, original_angle, target_angle in zip(metas, input_keys, [-60, 0, 60] * u.degree):
-        meta.update({
-            'POLAR': target_angle,
-            'POLARREF': "Solar",
-            "POLAROFF": input_collection[original_angle].meta.get("POLAROFF", 0 )
-        })
 
-    mask = combine_all_collection_masks(input_collection)
-    cube_list = [(key, NDCube(data_mzp_solar[:, :, i, 0], wcs=input_collection[input_keys[0]].wcs,
-                              mask=mask, meta=metas[i])) for i, key in enumerate(["M", "Z", "P"])]
+def _instrument_frame_analyzer_angles(input_collection: NDCollection):
+    data_shape = template_cube(input_collection, preferred_key="Z").data.shape
+    lats = compute_lats(input_collection["Z"].wcs, data_shape)
 
-    for p_angle in input_keys:
-        if p_angle.lower() == "alpha":
-            cube_list.append(("alpha", NDCube(input_collection["alpha"].data * u.radian,
-                                              wcs=input_collection[input_keys[0]].wcs,
-                                              meta=input_collection["alpha"].meta)))
-    return NDCollection(cube_list, meta={}, aligned_axes="all")
+    polarizer_difference = {
+        key: as_angle(input_collection[key].meta.get("POLAROFF", 0), u.degree) for key in ["M", "Z", "P"]
+    }
+    solar_north = {
+        key: solnorth_from_wcs(input_collection[key].wcs, shape=data_shape, precomputed_lats=lats)
+        for key in ["M", "Z", "P"]
+    }
+
+    return np.stack(
+        [
+            wrap_linear_polarization(solar_north["M"] + MZP_ANGLES[0] + polarizer_difference["M"]),
+            wrap_linear_polarization(solar_north["Z"] + MZP_ANGLES[1] + polarizer_difference["Z"]),
+            wrap_linear_polarization(solar_north["P"] + MZP_ANGLES[2] + polarizer_difference["P"]),
+        ]
+    )
+
+
+def _solar_north_angles(input_collection: NDCollection):
+    data_shape = template_cube(input_collection, preferred_key="Z").data.shape
+    lats = compute_lats(input_collection["Z"].wcs, data_shape)
+    return {
+        key: solnorth_from_wcs(input_collection[key].wcs, shape=data_shape, precomputed_lats=lats)
+        for key in ["M", "Z", "P"]
+    }
 
 
 @transform(System.mzpsolar, System.bpb, use_alpha=True)
@@ -128,37 +213,20 @@ def mzpsolar_to_bpb(input_collection, **kwargs):
     Equation 7 and 9 in DeForest et al. 2022.
 
     """""
-    # TODO: need to check if 3 angles are input.
-    # TODO: need to check if separated appropriately if not create quality warning.
-    input_dict = {}
-    in_list = list(input_collection)
+    alpha = _alpha_data(input_collection)
+    analyzer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
+    B, pB, pBp = bp3_from_analyzer_brightness(analyzer_stack, MZP_ANGLES, alpha)
+    _warn_if_information_is_lost(pBp, B, "mzpsolar_to_bpb")
 
-    for p_angle in in_list:
-        if p_angle == "alpha":
-            break
-        input_dict[input_collection[p_angle].meta["POLAR"]] = input_collection[p_angle].data
-
-    alpha = input_collection["alpha"].data * u.radian
-    B = (2 / 3) * (np.sum([ith_polarizer_brightness
-                           for ith_angle, ith_polarizer_brightness
-                           in input_dict.items() if ith_angle != "alpha"], axis=0))
-
-    pB = (-4 / 3) * (np.sum([ith_polarizer_brightness
-                             * np.cos(2 * (ith_angle - alpha))
-                             for ith_angle, ith_polarizer_brightness
-                             in input_dict.items() if ith_angle != "alpha"], axis=0))
-    metaB, metapB = copy.copy(input_collection["M"].meta), copy.copy(input_collection["M"].meta)
-    metaB.update(POLAR="B")
-    metapB.update(POLAR="pB")
-
-    mask = combine_all_collection_masks(input_collection)
-
-    BpB_cube = [("B", NDCube(B, wcs=input_collection["M"].wcs, mask=mask, meta=metaB)),
-                ("pB", NDCube(pB, wcs=input_collection["M"].wcs, mask=mask, meta=metapB)),
-                ("alpha", NDCube(alpha, wcs=input_collection["M"].wcs, mask=mask))]
-    # TODO: WCS for alpha needs to be generated wrt to solar north
-
-    return NDCollection(BpB_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="M")
+    shared_polaroff = _shared_polaroff(input_collection, ["M", "Z", "P"])
+    cubes = [
+        ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="B"))),
+        ("pB", NDCube(pB, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="pB"))),
+    ]
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.bpb, System.mzpsolar, use_alpha=True)
@@ -167,26 +235,13 @@ def bpb_to_mzpsolar(input_collection, **kwargs):
     -----
     Equation 4 in DeForest et al. 2022.
     """
-    alpha = input_collection["alpha"].data * u.radian
+    alpha = _alpha_data(input_collection)
     B, pB = input_collection["B"].data, input_collection["pB"].data
-    mzp_angles = [-60, 0, 60] * u.degree
-    Bmzp = {}
-    for angle in mzp_angles:
-        Bmzp[angle] = (1 / 2) * (B - pB * (np.cos(2 * (angle - alpha))))
-
-    metaM, metaZ, metaP = copy.copy(input_collection["B"].meta), copy.copy(input_collection["B"].meta), copy.copy(
-        input_collection["B"].meta)
-    metaM.update(POLAR=-60*u.degree, POLARREF='Solar')
-    metaZ.update(POLAR=0*u.degree, POLARREF='Solar')
-    metaP.update(POLAR=60*u.degree, POLARREF='Solar')
-    mask = combine_all_collection_masks(input_collection)
-    Bmzp_cube = [("M", NDCube(Bmzp[-60 * u.degree], wcs=input_collection["B"].wcs, mask=mask, meta=metaM)),
-                 ("Z", NDCube(Bmzp[0 * u.degree], wcs=input_collection["B"].wcs, mask=mask, meta=metaZ)),
-                 ("P", NDCube(Bmzp[60 * u.degree], wcs=input_collection["B"].wcs, mask=mask, meta=metaP)),
-                 ("alpha", NDCube(alpha, wcs=input_collection["B"].wcs))]
-    # TODO: WCS for alpha needs to be generated wrt to solar north
-
-    return NDCollection(Bmzp_cube, meta={}, aligned_axes="all")
+    mzp_stack = bp3_to_analyzer_brightness(B, pB, np.zeros_like(pB), alpha, MZP_ANGLES)
+    mask = combine_mask(input_collection)
+    cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="B")
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.bpb, System.btbr, use_alpha=True)
@@ -195,22 +250,18 @@ def bpb_to_btbr(input_collection, **kwargs):
     -----
     Equation 1 and 2 in DeForest et al. 2022.
     """
-    alpha = input_collection["alpha"].data * u.radian
     B, pB = input_collection["B"].data, input_collection["pB"].data
     Br = (B - pB) / 2
     Bt = (B + pB) / 2
 
-    metaBr, metaBt = copy.copy(input_collection["B"].meta), copy.copy(input_collection["B"].meta)
-    metaBr.update(POLAR="Br")
-    metaBt.update(POLAR="Bt")
-
-    mask = combine_all_collection_masks(input_collection)
-    BtBr_cube = [("Bt", NDCube(Bt, wcs=input_collection["B"].wcs, mask=mask, meta=metaBt)),
-                 ("Br", NDCube(Br, wcs=input_collection["B"].wcs, mask=mask, meta=metaBr)),
-                 ("alpha", NDCube(alpha, wcs=input_collection["B"].wcs))]
-    # TODO: WCS for alpha needs to be generated wrt to solar north
-
-    return NDCollection(BtBr_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="B")
+    cubes = [
+        ("Bt", NDCube(Bt, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Bt"))),
+        ("Br", NDCube(Br, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Br"))),
+    ]
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.btbr, System.bpb, use_alpha=True)
@@ -219,26 +270,18 @@ def btbr_to_bpb(input_collection, **kwargs):
     -----
     Equation in Table 1 in DeForest et al. 2022.
     """
-    if "alpha" not in input_collection:
-        msg = "missing alpha"
-        raise ValueError(msg)
-
-    alpha = input_collection["alpha"].data * u.radian
     Bt, Br = input_collection["Bt"].data, input_collection["Br"].data
     pB = (Bt - Br)
     B = (Bt + Br)
 
-    metaB, metapB = copy.copy(input_collection["Bt"].meta), copy.copy(input_collection["Bt"].meta)
-    metaB.update(POLAR="B")
-    metapB.update(POLAR="pB")
-
-    mask = combine_all_collection_masks(input_collection)
-    BpB_cube = [("B", NDCube(B, wcs=input_collection["Bt"].wcs, mask=mask, meta=metaB)),
-                ("pB", NDCube(pB, wcs=input_collection["Bt"].wcs, mask=mask, meta=metapB)),
-                ("alpha", NDCube(alpha, wcs=input_collection["Bt"].wcs, mask=mask))]
-    # TODO: WCS for alpha needs to be generated wrt to solar north
-
-    return NDCollection(BpB_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="Bt")
+    cubes = [
+        ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="B"))),
+        ("pB", NDCube(pB, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="pB"))),
+    ]
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.mzpsolar, System.stokes, use_alpha=False)
@@ -255,17 +298,15 @@ def mzpsolar_to_stokes(input_collection, **kwargs):
     Bq = mueller_matrix[1, 0] * Bm + mueller_matrix[1, 1] * Bz + mueller_matrix[1, 2] * Bp
     Bu = mueller_matrix[2, 0] * Bm + mueller_matrix[2, 1] * Bz + mueller_matrix[2, 2] * Bp
 
-    metaI, metaQ, metaU = copy.copy(input_collection["M"].meta), copy.copy(input_collection["Z"].meta), copy.copy(
-        input_collection["P"].meta)
-    metaI.update(POLAR="Stokes I")
-    metaQ.update(POLAR="Stokes Q")
-    metaU.update(POLAR="Stokes U")
-
-    mask = combine_all_collection_masks(input_collection)
-    BStokes_cube = [("I", NDCube(Bi, wcs=input_collection["M"].wcs, mask=mask, meta=metaI)),
-                    ("Q", NDCube(Bq, wcs=input_collection["M"].wcs, mask=mask, meta=metaQ)),
-                    ("U", NDCube(Bu, wcs=input_collection["M"].wcs, mask=mask, meta=metaU))]
-    return NDCollection(BStokes_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="M")
+    shared_polaroff = _shared_polaroff(input_collection, ["M", "Z", "P"])
+    cubes = [
+        ("I", NDCube(Bi, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="Stokes I"))),
+        ("Q", NDCube(Bq, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="Stokes Q"))),
+        ("U", NDCube(Bu, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="Stokes U"))),
+    ]
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.stokes, System.mzpsolar, use_alpha=False)
@@ -274,30 +315,24 @@ def stokes_to_mzpsolar(input_collection, **kwargs):
     -----
     Equation 11 in DeForest et al. 2022. with alpha = np.pi/2
     """
-    alpha = np.pi / 2
+    alpha = 90 * u.degree
     Bi, Bq, Bu = input_collection["I"].data, input_collection["Q"].data, input_collection["U"].data
 
-    inv_mul_mx = (1 / 2) * np.array([[1, -np.cos(2 * (-np.pi / 3 - alpha)), -np.sin(2 * (-np.pi / 3 - alpha))],
-                                     [1, -np.cos(2 * (0 - alpha)), 0],
-                                     [1, -np.cos(2 * (np.pi / 3 - alpha)), -np.sin(2 * (np.pi / 3 - alpha))]])
+    inv_mul_mx = (1 / 2) * np.array([
+        [1, -np.cos(2 * angle_difference_radians(-60 * u.degree, alpha)), -np.sin(2 * angle_difference_radians(-60 * u.degree, alpha))],
+        [1, -np.cos(2 * angle_difference_radians(0 * u.degree, alpha)), 0],
+        [1, -np.cos(2 * angle_difference_radians(60 * u.degree, alpha)), -np.sin(2 * angle_difference_radians(60 * u.degree, alpha))],
+    ])
 
     Bm = inv_mul_mx[0, 0] * Bi + inv_mul_mx[0, 1] * Bq + inv_mul_mx[0, 2] * Bu
     Bz = inv_mul_mx[1, 0] * Bi + inv_mul_mx[1, 1] * Bq + inv_mul_mx[1, 2] * Bu
     Bp = inv_mul_mx[2, 0] * Bi + inv_mul_mx[2, 1] * Bq + inv_mul_mx[2, 2] * Bu
 
-    metaM, metaZ, metaP = copy.copy(input_collection["I"].meta), copy.copy(input_collection["Q"].meta), copy.copy(
-        input_collection["U"].meta)
-    metaM.update(POLAR=-60*u.degree, POLARREF='Solar')
-    metaZ.update(POLAR=0*u.degree, POLARREF='Solar')
-    metaP.update(POLAR=60*u.degree, POLARREF='Solar')
-
-    mask = combine_all_collection_masks(input_collection)
-    Bmzp_cube = [("M", NDCube(Bm, wcs=input_collection["I"].wcs, mask=mask, meta=metaM)),
-                 ("Z", NDCube(Bz, wcs=input_collection["I"].wcs, mask=mask, meta=metaZ)),
-                 ("P", NDCube(Bp, wcs=input_collection["I"].wcs, mask=mask, meta=metaP)),
-                 ("alpha", NDCube(np.zeros_like(Bm) + alpha, wcs=input_collection["I"].wcs, mask=mask))]
-
-    return NDCollection(Bmzp_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    cubes = _mzp_cubes_from_stack([Bm, Bz, Bp], input_collection, mask=mask, preferred_key="I")
+    alpha_plane = np.full(np.shape(Bm), alpha.to_value(u.radian)) * u.radian
+    cubes.append(("alpha", NDCube(alpha_plane, wcs=input_collection["I"].wcs, mask=mask)))
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.mzpsolar, System.bp3, use_alpha=True)
@@ -307,41 +342,20 @@ def mzpsolar_to_bp3(input_collection, **kwargs):
     ------
     Equation 7, 9 and 10 in DeForest et al. 2022.
     """""
-    input_dict = {}
-    in_list = list(input_collection)
+    alpha = _alpha_data(input_collection)
+    analyzer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
+    B, pB, pBp = bp3_from_analyzer_brightness(analyzer_stack, MZP_ANGLES, alpha)
 
-    for p_angle in in_list:
-        if p_angle == "alpha":
-            break
-        input_dict[input_collection[p_angle].meta["POLAR"]] = input_collection[p_angle].data
-
-    alpha = input_collection["alpha"].data * u.radian
-    B = (2 / 3) * (np.sum([ith_polarizer_brightness for ith_angle, ith_polarizer_brightness
-                           in input_dict.items() if ith_angle != "alpha"], axis=0))
-
-    pB = (-4 / 3) * (np.sum([ith_polarizer_brightness
-                             * np.cos(2 * (ith_angle - alpha))
-                             for ith_angle, ith_polarizer_brightness
-                             in input_dict.items() if ith_angle != "alpha"], axis=0))
-
-    pBp = (-4 / 3) * (np.sum([ith_polarizer_brightness * np.sin(2 * (ith_angle - alpha))
-                              for ith_angle, ith_polarizer_brightness
-                              in input_dict.items() if ith_angle != "alpha"], axis=0))
-    # TODO: update header properly
-    metaB, metapB, metapBp = copy.copy(input_collection["M"].meta), copy.copy(input_collection["M"].meta), copy.copy(
-        input_collection["M"].meta)
-    metaB.update(POLAR="B")
-    metapB.update(POLAR="pB")
-    metapBp.update(POLAR="pB-prime")
-
-    mask = combine_all_collection_masks(input_collection)
-    Bp3_cube = [("B", NDCube(B, wcs=input_collection["M"].wcs, mask=mask, meta=metaB)),
-                ("pB", NDCube(pB, wcs=input_collection["M"].wcs, mask=mask, meta=metapB)),
-                ("pBp", NDCube(pBp, wcs=input_collection["M"].wcs, mask=mask, meta=metapBp)),
-                ("alpha", NDCube(alpha, wcs=input_collection["M"].wcs, mask=mask))]
-    # TODO: WCS for alpha needs to be generated wrt to solar north
-
-    return NDCollection(Bp3_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="M")
+    shared_polaroff = _shared_polaroff(input_collection, ["M", "Z", "P"])
+    cubes = [
+        ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="B"))),
+        ("pB", NDCube(pB, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="pB"))),
+        ("pBp", NDCube(pBp, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="pB-prime"))),
+    ]
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.bp3, System.mzpsolar, use_alpha=True)
@@ -352,27 +366,13 @@ def bp3_to_mzpsolar(input_collection, **kwargs):
     Equation 11 in DeForest et al. 2022.
     """""
     B, pB, pBp = input_collection["B"].data, input_collection["pB"].data, input_collection["pBp"].data
-    alpha = input_collection["alpha"].data * u.radian
+    alpha = _alpha_data(input_collection)
+    mzp_stack = bp3_to_analyzer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
 
-    mzp_angles = [-60, 0, 60] * u.degree
-    Bmzp = {}
-    for angle in mzp_angles:
-        Bmzp[angle] = (1 / 2) * (B - np.cos(2 * (angle - alpha)) * pB -
-                               np.cos(2 * (angle - alpha)) * pBp)
-
-    metaM, metaZ, metaP = copy.copy(input_collection["B"].meta), copy.copy(input_collection["pB"].meta), copy.copy(
-        input_collection["pBp"].meta)
-    metaM.update(POLAR=-60*u.degree, POLARREF='Solar')
-    metaZ.update(POLAR=0*u.degree, POLARREF='Solar')
-    metaP.update(POLAR=60*u.degree, POLARREF='Solar')
-
-    mask = combine_all_collection_masks(input_collection)
-    Bmzp_cube = [("M", NDCube(Bmzp[-60 * u.degree], wcs=input_collection["B"].wcs, mask=mask, meta=metaM)),
-                 ("Z", NDCube(Bmzp[0 * u.degree], wcs=input_collection["B"].wcs, mask=mask, meta=metaZ)),
-                 ("P", NDCube(Bmzp[60 * u.degree], wcs=input_collection["B"].wcs, mask=mask, meta=metaP)),
-                 ("alpha", NDCube(alpha, wcs=input_collection["B"].wcs, mask=mask))]
-
-    return NDCollection(Bmzp_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="B")
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.btbr, System.mzpsolar, use_alpha=True)
@@ -381,28 +381,21 @@ def btbr_to_mzpsolar(input_collection, **kwargs):
     -----
     Equation 3 in DeForest et al. 2022.
     """
-    alpha = input_collection["alpha"].data * u.radian
+    alpha = _alpha_data(input_collection)
     Bt = input_collection["Bt"].data
     Br = input_collection["Br"].data
 
-    mzp_angles = [-60, 0, 60] * u.degree
-    Bmzp = {}
-    for angle in mzp_angles:
-        Bmzp[angle] = Bt * (np.sin(angle - alpha)) ** 2 + Br * (np.cos(angle - alpha)) ** 2
-
-    metaM, metaZ, metaP = copy.copy(input_collection["Bt"].meta), copy.copy(input_collection["Bt"].meta), copy.copy(
-        input_collection["Bt"].meta)
-    metaM.update(POLAR=-60*u.degree, POLARREF='Solar')
-    metaZ.update(POLAR=0*u.degree, POLARREF='Solar')
-    metaP.update(POLAR=60*u.degree, POLARREF='Solar')
-
-    mask = combine_all_collection_masks(input_collection)
-    Bmzp_cube = [("M", NDCube(Bmzp[-60 * u.degree], wcs=input_collection["Bt"].wcs, mask=mask, meta=metaM)),
-                 ("Z", NDCube(Bmzp[0 * u.degree], wcs=input_collection["Bt"].wcs, mask=mask, meta=metaZ)),
-                 ("P", NDCube(Bmzp[60 * u.degree], wcs=input_collection["Bt"].wcs, mask=mask, meta=metaP)),
-                 ("alpha", NDCube(alpha, wcs=input_collection["Bt"].wcs, mask=mask))]
-
-    return NDCollection(Bmzp_cube, meta={}, aligned_axes="all")
+    mzp_stack = np.stack(
+        [
+            Bt * np.sin(angle_difference_radians(angle, alpha)) ** 2 + Br * np.cos(angle_difference_radians(angle, alpha)) ** 2
+            for angle in MZP_ANGLES
+        ],
+        axis=0,
+    )
+    mask = combine_mask(input_collection)
+    cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="Bt")
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.bp3, System.bthp, use_alpha=True)
@@ -413,21 +406,24 @@ def bp3_to_bthp(input_collection, **kwargs):
     Equations 9, 15, 16 in DeForest et al. 2022.
     """""
     B, pB, pBp = input_collection["B"].data, input_collection["pB"].data, input_collection["pBp"].data
-    alpha = input_collection["alpha"].data * u.radian
+    alpha = _alpha_data(input_collection)
 
-    theta = (1 / 2) * np.arctan2(pBp, pB) * u.radian + np.pi / 2 * u.radian + alpha
-    p = np.sqrt(pB ** 2 + pBp ** 2) / B
+    theta = wrap_linear_polarization(0.5 * np.arctan2(pBp, pB) * u.radian + np.pi / 2 * u.radian + alpha)
+    p = np.divide(
+        np.sqrt(pB ** 2 + pBp ** 2),
+        B,
+        out=np.full_like(B, np.nan, dtype=float),
+        where=np.not_equal(B, 0),
+    )
 
-    metaTh, metaP = copy.copy(input_collection["B"].meta), copy.copy(input_collection["pB"].meta)
-    metaTh.update(POLAR="Theta")
-    metaP.update(POLAR="Degree of Polarization")
-
-    mask = combine_all_collection_masks(input_collection)
-    Bthp_cube = [("B", NDCube(B, wcs=input_collection["B"].wcs, mask=mask, meta=input_collection["B"].meta)),
-                 ("theta", NDCube(theta, wcs=input_collection["B"].wcs, mask=mask, meta=metaTh)),
-                 ("p", NDCube(p, wcs=input_collection["B"].wcs, mask=mask, meta=metaP))]
-
-    return NDCollection(Bthp_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="B")
+    cubes = [
+        ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=template.meta)),
+        ("theta", NDCube(theta, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Theta"))),
+        ("p", NDCube(p, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Degree of Polarization"))),
+    ]
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.btbr, System.npol, use_alpha=True)
@@ -438,20 +434,49 @@ def btbr_to_npol(input_collection, out_angles: u.degree, **kwargs):
     Equation 3 in DeForest et al. 2022.
     angles: list of input angles in degree
     """
-    alpha = input_collection["alpha"].data * u.radian
+    alpha = _alpha_data(input_collection)
     Bt, Br = input_collection["Bt"].data, input_collection["Br"].data
 
-    Bnpol = {}
-    Bnpol_cube = []
-    mask = combine_all_collection_masks(input_collection)
+    cubes = []
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key="Bt")
     for angle in out_angles:
-        Bnpol[angle] = Bt * (np.sin(angle - alpha)) ** 2 + Br * (np.cos(angle - alpha)) ** 2
-        meta_tmp = copy.copy(input_collection["Bt"].meta)
-        meta_tmp.update(POLAR=angle)
-        Bnpol_cube.append((str(angle), NDCube(Bnpol[angle], wcs=input_collection["Bt"].wcs, mask=mask,  meta=meta_tmp)))
-    Bnpol_cube.append(("alpha", NDCube(alpha, wcs=input_collection["Bt"].wcs, mask=mask)))
+        value = Bt * np.sin(angle_difference_radians(angle, alpha)) ** 2 + Br * np.cos(angle_difference_radians(angle, alpha)) ** 2
+        cubes.append((str(angle), NDCube(value, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR=angle))))
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
-    return NDCollection(Bnpol_cube, meta={}, aligned_axes="all")
+
+@transform(System.npol, System.mzpsolar, use_alpha=False)
+@u.quantity_input
+def npol_to_mzpsolar(input_collection, in_angles: u.degree = None, reference_angle=0 * u.degree, **kwargs):
+    """
+    Notes
+    ------
+    Equation 44 in DeForest et al. 2022.
+    """
+    input_keys = data_keys(input_collection)
+    phi = (
+        in_angles
+        if in_angles is not None
+        else u.Quantity(
+            [
+                as_angle(input_collection[key].meta["POLAR"], u.degree)
+                for key in input_keys
+            ]
+        )
+    )
+
+    solved_stack = solve_three_polarizer_brightness(
+        np.stack(stack_data(input_collection, input_keys), axis=0),
+        observed_angles=phi,
+        solved_angles=MZP_ANGLES,
+        reference_angle=reference_angle,
+    )
+    mask = combine_mask(input_collection)
+    cube_list = _mzp_cubes_from_stack(solved_stack, input_collection, mask=mask)
+    _append_alpha(cube_list, input_collection, mask=mask)
+    return _collection_from_cubes(cube_list)
 
 
 @transform(System.mzpsolar, System.npol, use_alpha=False)
@@ -462,42 +487,41 @@ def mzpsolar_to_npol(input_collection, out_angles: u.degree, reference_angle=0 *
     Equation 45 in DeForest et al. 2022.
     angles: list of input angles in degree
     """
-    in_keys = [key for key in input_collection if key != "alpha"]
+    in_keys = data_keys(input_collection)
+    source_angles = u.Quantity(
+        [
+            as_angle(input_collection[key].meta["POLAR"], u.degree)
+            for key in in_keys
+        ]
+    )
+    source_stack = np.stack(stack_data(input_collection, in_keys), axis=0)
+    projected = project_three_polarizer_brightness(
+        source_stack,
+        source_angles=source_angles,
+        target_angles=out_angles,
+        reference_angle=reference_angle,
+    )
 
-    polarizer_difference = {key: input_collection[key].meta["POLAROFF"] * u.deg
-                        if "POLAROFF" in input_collection[key].meta
-                        else 0 * u.deg
-                        for key in in_keys}
-
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection)
+    shared_polaroff = _shared_polaroff(input_collection, in_keys)
     output_cubes = []
-    mask = combine_all_collection_masks(input_collection)
-    first_meta = input_collection[in_keys[0]].meta
-    first_wcs = input_collection[in_keys[0]].wcs
+    for angle, value in zip(out_angles, projected, strict=False):
+        out_key = str(np.round(np.mean(angle).value)) if getattr(out_angles, "ndim", 1) > 1 else str(angle)
+        output_cubes.append(
+            (
+                out_key,
+                NDCube(
+                    value,
+                    wcs=template.wcs,
+                    mask=mask,
+                    meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR=angle),
+                ),
+            )
+        )
 
-    for out_angle in out_angles:
-        terms = []
-        for key in in_keys:
-            input_angle = input_collection[key].meta["POLAR"]
-            input_data = input_collection[key].data
-            angle_eff = input_angle + polarizer_difference[key]
-
-            coeff = (4 * np.cos(out_angle - angle_eff - reference_angle) ** 2 - 1) / 3
-            terms.append(input_data * coeff)
-        value = np.sum(terms, axis=0)
-
-        out_meta = copy.copy(first_meta)
-        out_meta.update(POLAR=out_angle)
-        if out_angles.ndim > 1:
-            out_key = str(np.round(np.mean(out_angle).value))
-        else:
-            out_key = str(out_angle)
-        output_cubes.append((out_key, NDCube(value, wcs=first_wcs, mask=mask, meta=out_meta)))
-
-    if "alpha" in input_collection:
-        alpha = input_collection["alpha"].data * u.radian
-        output_cubes.append(("alpha", NDCube(alpha, wcs=first_wcs, mask=mask)))
-
-    return NDCollection(output_cubes, meta={}, aligned_axes="all")
+    _append_alpha(output_cubes, input_collection, mask=mask)
+    return _collection_from_cubes(output_cubes)
 
 
 @transform(System.fourpol, System.stokes, use_alpha=False)
@@ -512,19 +536,14 @@ def fourpol_to_stokes(input_collection, **kwargs):
     Bq = input_collection[str(90 * u.degree)].data - input_collection[str(0 * u.degree)].data
     Bu = input_collection[str(135 * u.degree)].data - input_collection[str(45 * u.degree)].data
 
-    metaI, metaQ, metaU = (copy.copy(input_collection[str(0 * u.degree)].meta),
-                           copy.copy(input_collection[str(0 * u.degree)].meta),
-                           copy.copy(input_collection[str(0 * u.degree)].meta))
-    metaI.update(POLAR="Stokes I")
-    metaQ.update(POLAR="Stokes Q")
-    metaU.update(POLAR="Stokes U")
-
-    mask = combine_all_collection_masks(input_collection)
-    BStokes_cube = [("I", NDCube(Bi, wcs=input_collection[str(0 * u.degree)].wcs, mask=mask, meta=metaI)),
-                    ("Q", NDCube(Bq, wcs=input_collection[str(0 * u.degree)].wcs, mask=mask, meta=metaQ)),
-                    ("U", NDCube(Bu, wcs=input_collection[str(0 * u.degree)].wcs, mask=mask, meta=metaU))]
-
-    return NDCollection(BStokes_cube, meta={}, aligned_axes="all")
+    mask = combine_mask(input_collection)
+    template = template_cube(input_collection, preferred_key=str(0 * u.degree))
+    cubes = [
+        ("I", NDCube(Bi, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Stokes I"))),
+        ("Q", NDCube(Bq, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Stokes Q"))),
+        ("U", NDCube(Bu, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Stokes U"))),
+    ]
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.mzpsolar, System.mzpinstru, use_alpha=False)
@@ -534,96 +553,90 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
         Equation 45 in DeForest et al. 2022.
         out_angles: list of target angles in degree
         """
-    in_list = list(input_collection)
-    input_dict = {}
-
-    for p_angle in in_list:
-        if p_angle == "alpha":
-            break
-        input_dict[input_collection[p_angle].meta["POLAR"]] = input_collection[p_angle].data
-
-    input_keys = list(input_collection.keys())
-    polarizer_difference = {k: input_collection[k].meta['POLAROFF'] * u.degree if 'POLAROFF' in input_collection[
-         k].meta else 0 * u.degree for k in ['M', 'Z', 'P']}
-
-    data_shape = input_collection[input_keys[0]].data.shape
-
-    lats = compute_lats(input_collection['Z'].wcs, data_shape)
-    angle_solar_north_m = (solnorth_from_wcs(input_collection['M'].wcs, shape=data_shape, precomputed_lats=lats)
-                           + (60 * u.degree + polarizer_difference['M'])) % (-180 * u.degree)
-    angle_solar_north_z = (solnorth_from_wcs(input_collection['Z'].wcs, shape=data_shape, precomputed_lats=lats)
-                           + polarizer_difference['Z']) % (180 * u.degree)
-    angle_solar_north_p = (solnorth_from_wcs(input_collection['P'].wcs, shape=data_shape, precomputed_lats=lats)
-                           - (60 * u.degree + polarizer_difference['P'])) % (180 * u.degree)
-    in_angles = np.stack([angle_solar_north_m, angle_solar_north_z, angle_solar_north_p])
-
-    output_cubes = []
-    mask = combine_all_collection_masks(input_collection)
-    for out_angle, key in zip([-60, 0, 60] * u.deg, ["M", "Z", "P"]):
+    mask = combine_mask(input_collection)
+    solar_north = _solar_north_angles(input_collection)
+    cubes = []
+    input_triplet = {
+        key: (as_angle(input_collection[key].meta["POLAR"], u.degree), input_collection[key].data)
+        for key in ["M", "Z", "P"]
+    }
+    for key in ["M", "Z", "P"]:
+        nominal_angle = as_angle(input_collection[key].meta["POLAR"], u.degree)
+        polaroff = as_angle(input_collection[key].meta.get("POLAROFF", 0), u.degree)
+        alpha_j = nominal_angle + polaroff
+        phi = wrap_linear_polarization(alpha_j - solar_north[key])
         value = (1 / 3) * np.sum(
-            [input_collection[angle].data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
-             for input_angle, angle in zip(in_angles, ["M", "Z", "P"])], axis=0)
-        out_meta = copy.deepcopy(input_collection[key].meta)
-        out_meta['POLARREF'] = "Instrument"
-        output_cubes.append((key,
-                             NDCube(value, wcs=input_collection[key].wcs, mask=mask, meta=out_meta)))
-
-    if "alpha" in input_collection:
-        alpha = input_collection["alpha"].data * u.radian
-        output_cubes.append(("alpha", NDCube(alpha, wcs=input_collection[in_list[0]].wcs, mask=mask)))
-
-    return NDCollection(output_cubes, meta={}, aligned_axes="all")
+            [
+                data_i * (4 * np.cos(angle_difference_radians(phi, theta_i + reference_angle)) ** 2 - 1)
+                for theta_i, data_i in input_triplet.values()
+            ],
+            axis=0,
+        )
+        cubes.append(
+            (
+                key,
+                NDCube(
+                    value,
+                    wcs=input_collection[key].wcs,
+                    mask=mask,
+                    meta=clone_meta(
+                        input_collection[key],
+                        POLARREF="Instrument",
+                        POLAR=nominal_angle,
+                        POLAROFF=polaroff,
+                    ),
+                ),
+            )
+        )
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 
 @transform(System.mzpinstru, System.mzpsolar, use_alpha=False)
 def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs):
-     """Notes
-     -----
-     Equation 45 in DeForest et al. 2022.
-     angles: list of input angles in degree
-     """
-     in_list = list(input_collection)
-     input_dict = {}
-
-     for p_angle in in_list:
-         if p_angle == "alpha":
-             break
-         input_dict[input_collection[p_angle].meta["POLAR"]] = input_collection[p_angle].data
-
-     input_keys = list(input_collection.keys())
-     polarizer_difference = {k: input_collection[k].meta['POLAROFF'] * u.degree if 'POLAROFF' in input_collection[
-         k].meta else 0 * u.degree for k in ['M', 'Z', 'P']}
-
-     data_shape = input_collection[input_keys[0]].data.shape
-
-     lats = compute_lats(input_collection['Z'].wcs, data_shape)
-     angle_solar_north_m = (solnorth_from_wcs(input_collection['M'].wcs, shape=data_shape, precomputed_lats=lats)
-                            + (60 * u.degree + polarizer_difference['M'])) % (-180 * u.degree)
-     angle_solar_north_z = (solnorth_from_wcs(input_collection['Z'].wcs, shape=data_shape, precomputed_lats=lats)
-                            + polarizer_difference['Z']) % (180 * u.degree)
-     angle_solar_north_p = (solnorth_from_wcs(input_collection['P'].wcs, shape=data_shape, precomputed_lats=lats)
-                            - (60 * u.degree + polarizer_difference['P'])) % (180 * u.degree)
-
-     out_angles = np.stack([angle_solar_north_m, angle_solar_north_z, angle_solar_north_p])
-
-     output_cubes = []
-     mask = combine_all_collection_masks(input_collection)
-     first_meta = input_collection[in_list[0]].meta
-     first_wcs = input_collection[in_list[0]].wcs
-     for out_angle, key in zip(out_angles, ["M", "Z", "P"]):
-         value = (1 / 3) * np.sum(
-             [input_cube.data * (4 * np.square(np.cos(out_angle - input_angle - reference_angle)) - 1)
-              for input_angle, input_cube in input_dict.items()], axis=0)
-         out_meta = copy.deepcopy(first_meta)
-         out_meta['POLARREF'] = "Solar"
-         output_cubes.append((key,
-                              NDCube(value, wcs=first_wcs, mask=mask, meta=out_meta)))
-
-     if "alpha" in input_collection:
-         alpha = input_collection["alpha"].data * u.radian
-         output_cubes.append(("alpha", NDCube(alpha, wcs=input_collection[in_list[0]].wcs, mask=mask)))
-
-     return NDCollection(output_cubes, meta={}, aligned_axes="all")
+    """Notes
+    -----
+    Equation 45 in DeForest et al. 2022.
+    angles: list of input angles in degree
+    """
+    mask = combine_mask(input_collection)
+    solar_north = _solar_north_angles(input_collection)
+    input_triplet = {
+        key: (
+            as_angle(input_collection[key].meta["POLAR"], u.degree)
+            + as_angle(input_collection[key].meta.get("POLAROFF", 0), u.degree),
+            input_collection[key].data,
+        )
+        for key in ["M", "Z", "P"]
+    }
+    cubes = []
+    for key, mzp_angle in zip(["M", "Z", "P"], MZP_ANGLES, strict=False):
+        phi = wrap_linear_polarization(solar_north[key] + mzp_angle)
+        value = (1 / 3) * np.sum(
+            [
+                data_i * (4 * np.cos(angle_difference_radians(phi, theta_i + reference_angle)) ** 2 - 1)
+                for theta_i, data_i in input_triplet.values()
+            ],
+            axis=0,
+        )
+        cubes.append(
+            (
+                key,
+                NDCube(
+                    value,
+                    wcs=input_collection[key].wcs,
+                    mask=mask,
+                    meta=clone_meta(
+                        input_collection[key],
+                        POLARREF="Solar",
+                        POLAR=mzp_angle,
+                        POLAROFF=as_angle(input_collection[key].meta.get("POLAROFF", 0), u.degree),
+                    ),
+                ),
+            )
+        )
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
 
 # Build the graph at the bottom so all transforms are defined
 transform_graph = nx.DiGraph()
@@ -631,6 +644,7 @@ transform_functions = getmembers(sys.modules[__name__], isfunction)
 for function_name, function in transform_functions:
     if "_to_" in function_name:
         source, destination = function_name.split("_to_")
-        transform_graph.add_edge(System[source.lower()],
-                                 System[destination.lower()],
-                                 func=function)
+        if source.lower() in System.__members__ and destination.lower() in System.__members__:
+            transform_graph.add_edge(System[source.lower()],
+                                     System[destination.lower()],
+                                     func=function)

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -14,9 +14,9 @@ from solpolpy.errors import InvalidDataError, MissingAlphaError
 from solpolpy.physics import (
     MZP_ANGLES,
     as_angle,
-    bp3_from_analyzer_brightness,
-    bp3_to_analyzer_brightness,
     calculate_angle_difference,
+    bp3_from_polarizer_brightness,
+    bp3_to_polarizer_brightness,
     clone_meta,
     get_data_keys,
     get_template_cube,
@@ -194,8 +194,8 @@ def _mzp_cubes_from_stack(
     return cubes
 
 
-def _instrument_frame_analyzer_angles(input_collection: NDCollection) -> u.Quantity:
-    """Return M/Z/P analyzer angles in the instrument frame."""
+def _instrument_frame_polarizer_angles(input_collection: NDCollection) -> u.Quantity:
+    """Return M/Z/P polarizer angles in the instrument frame."""
     data_shape = get_template_cube(input_collection, preferred_key="Z").data.shape
     lats = compute_lats(input_collection["Z"].wcs, data_shape)
 
@@ -235,8 +235,8 @@ def mzpsolar_to_bpb(input_collection, **kwargs):
 
     """""
     alpha = _alpha_data(input_collection)
-    analyzer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
-    B, pB, pBp = bp3_from_analyzer_brightness(analyzer_stack, MZP_ANGLES, alpha)
+    polarizer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
+    B, pB, pBp = bp3_from_polarizer_brightness(polarizer_stack, MZP_ANGLES, alpha)
     _warn_if_information_is_lost(pBp, B, "mzpsolar_to_bpb")
 
     mask = combine_all_collection_masks(input_collection)
@@ -258,7 +258,7 @@ def bpb_to_mzpsolar(input_collection, **kwargs):
     """
     alpha = _alpha_data(input_collection)
     B, pB = input_collection["B"].data, input_collection["pB"].data
-    mzp_stack = bp3_to_analyzer_brightness(B, pB, np.zeros_like(pB), alpha, MZP_ANGLES)
+    mzp_stack = bp3_to_polarizer_brightness(B, pB, np.zeros_like(pB), alpha, MZP_ANGLES)
     mask = combine_all_collection_masks(input_collection)
     cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="B")
     _append_alpha(cubes, input_collection, mask=mask)
@@ -364,8 +364,8 @@ def mzpsolar_to_bp3(input_collection, **kwargs):
     Equation 7, 9 and 10 in DeForest et al. 2022.
     """""
     alpha = _alpha_data(input_collection)
-    analyzer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
-    B, pB, pBp = bp3_from_analyzer_brightness(analyzer_stack, MZP_ANGLES, alpha)
+    polarizer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
+    B, pB, pBp = bp3_from_polarizer_brightness(polarizer_stack, MZP_ANGLES, alpha)
 
     mask = combine_all_collection_masks(input_collection)
     template = get_template_cube(input_collection, preferred_key="M")
@@ -388,7 +388,7 @@ def bp3_to_mzpsolar(input_collection, **kwargs):
     """""
     B, pB, pBp = input_collection["B"].data, input_collection["pB"].data, input_collection["pBp"].data
     alpha = _alpha_data(input_collection)
-    mzp_stack = bp3_to_analyzer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
+    mzp_stack = bp3_to_polarizer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
 
     mask = combine_all_collection_masks(input_collection)
     cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="B")

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -14,9 +14,9 @@ from solpolpy.errors import InvalidDataError, MissingAlphaError
 from solpolpy.physics import (
     MZP_ANGLES,
     as_angle,
-    calculate_angle_difference,
     bp3_from_polarizer_brightness,
     bp3_to_polarizer_brightness,
+    calculate_angle_difference,
     clone_meta,
     get_data_keys,
     get_template_cube,

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -13,20 +13,19 @@ from ndcube import NDCollection, NDCube
 from solpolpy.errors import InvalidDataError, MissingAlphaError
 from solpolpy.physics import (
     MZP_ANGLES,
-    angle_difference_radians,
     as_angle,
     bp3_from_analyzer_brightness,
     bp3_to_analyzer_brightness,
+    calculate_angle_difference,
     clone_meta,
-    combine_mask,
-    data_keys,
+    get_data_keys,
+    get_template_cube,
     project_three_polarizer_brightness,
     solve_three_polarizer_brightness,
     stack_data,
-    template_cube,
     wrap_linear_polarization,
 )
-from solpolpy.util import compute_lats, solnorth_from_wcs
+from solpolpy.util import combine_all_collection_masks, compute_lats, solnorth_from_wcs
 
 System = StrEnum("System", ["bpb", "npol", "stokes", "mzpsolar", "mzpinstru", "btbr", "bthp", "fourpol", "bp3"])
 SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},
@@ -41,11 +40,14 @@ SYSTEM_REQUIRED_KEYS = {System.bpb: {"B", "pB"},
                         }
 
 
-def transform(source_system, target_system, use_alpha):
+def transform(source_system: System, target_system: System, use_alpha: bool):
     """Decorator for transforms."""
     def decorator(transform_function):
         transform_signature = signature(transform_function)
         transform_parameters = transform_signature.parameters
+        # ``uses_*`` means the transform accepts optional angle arguments that
+        # may need to be forwarded through a composed path. ``requires_*`` is
+        # stricter: the argument has no default and must be provided by resolve.
         uses_out_angles = "out_angles" in transform_parameters
         uses_in_angles = "in_angles" in transform_parameters
         requires_out_angles = uses_out_angles and transform_parameters["out_angles"].default is transform_signature.empty
@@ -79,15 +81,23 @@ def transform(source_system, target_system, use_alpha):
     return decorator
 
 
-def _alpha_data(collection: NDCollection):
+def _alpha_data(collection: NDCollection) -> u.Quantity:
+    """Return the alpha cube data as radians."""
     return as_angle(collection["alpha"].data, u.radian).to(u.radian)
 
 
-def _collection_from_cubes(cubes):
+def _angle_difference_radians(target_angle: u.Quantity, source_angle: u.Quantity) -> np.ndarray:
+    """Return a wrapped angle difference in radian values for trigonometry."""
+    return calculate_angle_difference(as_angle(target_angle, u.radian), as_angle(source_angle, u.radian)).to_value(u.radian)
+
+
+def _collection_from_cubes(cubes: list[tuple[str, NDCube]]) -> NDCollection:
+    """Build a consistently aligned collection from transform output cubes."""
     return NDCollection(cubes, meta={}, aligned_axes="all")
 
 
-def _shared_polaroff(input_collection: NDCollection, keys):
+def _shared_polaroff(input_collection: NDCollection, keys: list[str]) -> u.Quantity | None:
+    """Return the shared POLAROFF value when output metadata can preserve it."""
     offsets = []
     for key in keys:
         if key in input_collection and "POLAROFF" in input_collection[key].meta:
@@ -107,7 +117,8 @@ def _shared_polaroff(input_collection: NDCollection, keys):
     return None
 
 
-def _meta_with_shared_polaroff(cube, shared_polaroff, **updates):
+def _meta_with_shared_polaroff(cube: NDCube, shared_polaroff: u.Quantity | None, **updates):
+    """Clone cube metadata and preserve POLAROFF only when it is unambiguous."""
     meta = clone_meta(cube, **updates)
     if shared_polaroff is None:
         meta.pop("POLAROFF", None)
@@ -116,7 +127,8 @@ def _meta_with_shared_polaroff(cube, shared_polaroff, **updates):
     return meta
 
 
-def _warn_if_information_is_lost(pBp, B, context):
+def _warn_if_information_is_lost(pBp: np.ndarray, B: np.ndarray, context: str) -> None:
+    """Warn when a lossy BP3 to BPB-style projection drops nonzero pBp."""
     with np.errstate(divide="ignore", invalid="ignore"):
         relative_pbp = np.abs(
             np.divide(
@@ -138,7 +150,8 @@ def _warn_if_information_is_lost(pBp, B, context):
         )
 
 
-def _append_alpha(cubes, input_collection: NDCollection, mask=None):
+def _append_alpha(cubes: list[tuple[str, NDCube]], input_collection: NDCollection, mask: np.ndarray | None = None) -> list[tuple[str, NDCube]]:
+    """Append alpha to an output cube list when the input collection had it."""
     if "alpha" not in input_collection:
         return cubes
     alpha_cube = input_collection["alpha"]
@@ -156,9 +169,15 @@ def _append_alpha(cubes, input_collection: NDCollection, mask=None):
     return cubes
 
 
-def _mzp_cubes_from_stack(data_stack, input_collection: NDCollection, mask=None, preferred_key: str | None = None):
-    cube_template = template_cube(input_collection, preferred_key=preferred_key)
-    shared_polaroff = _shared_polaroff(input_collection, data_keys(input_collection))
+def _mzp_cubes_from_stack(
+    data_stack: np.ndarray,
+    input_collection: NDCollection,
+    mask: np.ndarray | None = None,
+    preferred_key: str | None = None,
+) -> list[tuple[str, NDCube]]:
+    """Convert a three-plane M/Z/P data stack into named NDCubes."""
+    cube_template = get_template_cube(input_collection, preferred_key=preferred_key)
+    shared_polaroff = _shared_polaroff(input_collection, get_data_keys(input_collection))
     cubes = []
     for key, angle, data in zip(["M", "Z", "P"], MZP_ANGLES, data_stack, strict=False):
         cubes.append(
@@ -175,8 +194,9 @@ def _mzp_cubes_from_stack(data_stack, input_collection: NDCollection, mask=None,
     return cubes
 
 
-def _instrument_frame_analyzer_angles(input_collection: NDCollection):
-    data_shape = template_cube(input_collection, preferred_key="Z").data.shape
+def _instrument_frame_analyzer_angles(input_collection: NDCollection) -> u.Quantity:
+    """Return M/Z/P analyzer angles in the instrument frame."""
+    data_shape = get_template_cube(input_collection, preferred_key="Z").data.shape
     lats = compute_lats(input_collection["Z"].wcs, data_shape)
 
     polarizer_difference = {
@@ -196,8 +216,9 @@ def _instrument_frame_analyzer_angles(input_collection: NDCollection):
     )
 
 
-def _solar_north_angles(input_collection: NDCollection):
-    data_shape = template_cube(input_collection, preferred_key="Z").data.shape
+def _solar_north_angles(input_collection: NDCollection) -> dict[str, u.Quantity]:
+    """Return solar-north angles for each M/Z/P input cube."""
+    data_shape = get_template_cube(input_collection, preferred_key="Z").data.shape
     lats = compute_lats(input_collection["Z"].wcs, data_shape)
     return {
         key: solnorth_from_wcs(input_collection[key].wcs, shape=data_shape, precomputed_lats=lats)
@@ -218,8 +239,8 @@ def mzpsolar_to_bpb(input_collection, **kwargs):
     B, pB, pBp = bp3_from_analyzer_brightness(analyzer_stack, MZP_ANGLES, alpha)
     _warn_if_information_is_lost(pBp, B, "mzpsolar_to_bpb")
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="M")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="M")
     shared_polaroff = _shared_polaroff(input_collection, ["M", "Z", "P"])
     cubes = [
         ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="B"))),
@@ -238,7 +259,7 @@ def bpb_to_mzpsolar(input_collection, **kwargs):
     alpha = _alpha_data(input_collection)
     B, pB = input_collection["B"].data, input_collection["pB"].data
     mzp_stack = bp3_to_analyzer_brightness(B, pB, np.zeros_like(pB), alpha, MZP_ANGLES)
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="B")
     _append_alpha(cubes, input_collection, mask=mask)
     return _collection_from_cubes(cubes)
@@ -254,8 +275,8 @@ def bpb_to_btbr(input_collection, **kwargs):
     Br = (B - pB) / 2
     Bt = (B + pB) / 2
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="B")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="B")
     cubes = [
         ("Bt", NDCube(Bt, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Bt"))),
         ("Br", NDCube(Br, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Br"))),
@@ -274,8 +295,8 @@ def btbr_to_bpb(input_collection, **kwargs):
     pB = (Bt - Br)
     B = (Bt + Br)
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="Bt")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="Bt")
     cubes = [
         ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="B"))),
         ("pB", NDCube(pB, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="pB"))),
@@ -298,8 +319,8 @@ def mzpsolar_to_stokes(input_collection, **kwargs):
     Bq = mueller_matrix[1, 0] * Bm + mueller_matrix[1, 1] * Bz + mueller_matrix[1, 2] * Bp
     Bu = mueller_matrix[2, 0] * Bm + mueller_matrix[2, 1] * Bz + mueller_matrix[2, 2] * Bp
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="M")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="M")
     shared_polaroff = _shared_polaroff(input_collection, ["M", "Z", "P"])
     cubes = [
         ("I", NDCube(Bi, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="Stokes I"))),
@@ -319,16 +340,16 @@ def stokes_to_mzpsolar(input_collection, **kwargs):
     Bi, Bq, Bu = input_collection["I"].data, input_collection["Q"].data, input_collection["U"].data
 
     inv_mul_mx = (1 / 2) * np.array([
-        [1, -np.cos(2 * angle_difference_radians(-60 * u.degree, alpha)), -np.sin(2 * angle_difference_radians(-60 * u.degree, alpha))],
-        [1, -np.cos(2 * angle_difference_radians(0 * u.degree, alpha)), 0],
-        [1, -np.cos(2 * angle_difference_radians(60 * u.degree, alpha)), -np.sin(2 * angle_difference_radians(60 * u.degree, alpha))],
+        [1, -np.cos(2 * _angle_difference_radians(-60 * u.degree, alpha)), -np.sin(2 * _angle_difference_radians(-60 * u.degree, alpha))],
+        [1, -np.cos(2 * _angle_difference_radians(0 * u.degree, alpha)), 0],
+        [1, -np.cos(2 * _angle_difference_radians(60 * u.degree, alpha)), -np.sin(2 * _angle_difference_radians(60 * u.degree, alpha))],
     ])
 
     Bm = inv_mul_mx[0, 0] * Bi + inv_mul_mx[0, 1] * Bq + inv_mul_mx[0, 2] * Bu
     Bz = inv_mul_mx[1, 0] * Bi + inv_mul_mx[1, 1] * Bq + inv_mul_mx[1, 2] * Bu
     Bp = inv_mul_mx[2, 0] * Bi + inv_mul_mx[2, 1] * Bq + inv_mul_mx[2, 2] * Bu
 
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     cubes = _mzp_cubes_from_stack([Bm, Bz, Bp], input_collection, mask=mask, preferred_key="I")
     alpha_plane = np.full(np.shape(Bm), alpha.to_value(u.radian)) * u.radian
     cubes.append(("alpha", NDCube(alpha_plane, wcs=input_collection["I"].wcs, mask=mask)))
@@ -346,8 +367,8 @@ def mzpsolar_to_bp3(input_collection, **kwargs):
     analyzer_stack = np.stack(stack_data(input_collection, ["M", "Z", "P"]), axis=0)
     B, pB, pBp = bp3_from_analyzer_brightness(analyzer_stack, MZP_ANGLES, alpha)
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="M")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="M")
     shared_polaroff = _shared_polaroff(input_collection, ["M", "Z", "P"])
     cubes = [
         ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=_meta_with_shared_polaroff(template, shared_polaroff, POLAR="B"))),
@@ -369,7 +390,7 @@ def bp3_to_mzpsolar(input_collection, **kwargs):
     alpha = _alpha_data(input_collection)
     mzp_stack = bp3_to_analyzer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
 
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="B")
     _append_alpha(cubes, input_collection, mask=mask)
     return _collection_from_cubes(cubes)
@@ -387,12 +408,12 @@ def btbr_to_mzpsolar(input_collection, **kwargs):
 
     mzp_stack = np.stack(
         [
-            Bt * np.sin(angle_difference_radians(angle, alpha)) ** 2 + Br * np.cos(angle_difference_radians(angle, alpha)) ** 2
+            Bt * np.sin(_angle_difference_radians(angle, alpha)) ** 2 + Br * np.cos(_angle_difference_radians(angle, alpha)) ** 2
             for angle in MZP_ANGLES
         ],
         axis=0,
     )
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     cubes = _mzp_cubes_from_stack(mzp_stack, input_collection, mask=mask, preferred_key="Bt")
     _append_alpha(cubes, input_collection, mask=mask)
     return _collection_from_cubes(cubes)
@@ -416,8 +437,8 @@ def bp3_to_bthp(input_collection, **kwargs):
         where=np.not_equal(B, 0),
     )
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="B")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="B")
     cubes = [
         ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=template.meta)),
         ("theta", NDCube(theta, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Theta"))),
@@ -438,10 +459,10 @@ def btbr_to_npol(input_collection, out_angles: u.degree, **kwargs):
     Bt, Br = input_collection["Bt"].data, input_collection["Br"].data
 
     cubes = []
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key="Bt")
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="Bt")
     for angle in out_angles:
-        value = Bt * np.sin(angle_difference_radians(angle, alpha)) ** 2 + Br * np.cos(angle_difference_radians(angle, alpha)) ** 2
+        value = Bt * np.sin(_angle_difference_radians(angle, alpha)) ** 2 + Br * np.cos(_angle_difference_radians(angle, alpha)) ** 2
         cubes.append((str(angle), NDCube(value, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR=angle))))
     _append_alpha(cubes, input_collection, mask=mask)
     return _collection_from_cubes(cubes)
@@ -455,7 +476,7 @@ def npol_to_mzpsolar(input_collection, in_angles: u.degree = None, reference_ang
     ------
     Equation 44 in DeForest et al. 2022.
     """
-    input_keys = data_keys(input_collection)
+    input_keys = get_data_keys(input_collection)
     phi = (
         in_angles
         if in_angles is not None
@@ -473,7 +494,7 @@ def npol_to_mzpsolar(input_collection, in_angles: u.degree = None, reference_ang
         solved_angles=MZP_ANGLES,
         reference_angle=reference_angle,
     )
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     cube_list = _mzp_cubes_from_stack(solved_stack, input_collection, mask=mask)
     _append_alpha(cube_list, input_collection, mask=mask)
     return _collection_from_cubes(cube_list)
@@ -487,7 +508,7 @@ def mzpsolar_to_npol(input_collection, out_angles: u.degree, reference_angle=0 *
     Equation 45 in DeForest et al. 2022.
     angles: list of input angles in degree
     """
-    in_keys = data_keys(input_collection)
+    in_keys = get_data_keys(input_collection)
     source_angles = u.Quantity(
         [
             as_angle(input_collection[key].meta["POLAR"], u.degree)
@@ -502,8 +523,8 @@ def mzpsolar_to_npol(input_collection, out_angles: u.degree, reference_angle=0 *
         reference_angle=reference_angle,
     )
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection)
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection)
     shared_polaroff = _shared_polaroff(input_collection, in_keys)
     output_cubes = []
     for angle, value in zip(out_angles, projected, strict=False):
@@ -536,8 +557,8 @@ def fourpol_to_stokes(input_collection, **kwargs):
     Bq = input_collection[str(90 * u.degree)].data - input_collection[str(0 * u.degree)].data
     Bu = input_collection[str(135 * u.degree)].data - input_collection[str(45 * u.degree)].data
 
-    mask = combine_mask(input_collection)
-    template = template_cube(input_collection, preferred_key=str(0 * u.degree))
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key=str(0 * u.degree))
     cubes = [
         ("I", NDCube(Bi, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Stokes I"))),
         ("Q", NDCube(Bq, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Stokes Q"))),
@@ -553,7 +574,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
         Equation 45 in DeForest et al. 2022.
         out_angles: list of target angles in degree
         """
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     solar_north = _solar_north_angles(input_collection)
     cubes = []
     input_triplet = {
@@ -567,7 +588,7 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
         phi = wrap_linear_polarization(alpha_j - solar_north[key])
         value = (1 / 3) * np.sum(
             [
-                data_i * (4 * np.cos(angle_difference_radians(phi, theta_i + reference_angle)) ** 2 - 1)
+                data_i * (4 * np.cos(_angle_difference_radians(phi, theta_i + reference_angle)) ** 2 - 1)
                 for theta_i, data_i in input_triplet.values()
             ],
             axis=0,
@@ -599,7 +620,7 @@ def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs
     Equation 45 in DeForest et al. 2022.
     angles: list of input angles in degree
     """
-    mask = combine_mask(input_collection)
+    mask = combine_all_collection_masks(input_collection)
     solar_north = _solar_north_angles(input_collection)
     input_triplet = {
         key: (
@@ -614,7 +635,7 @@ def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs
         phi = wrap_linear_polarization(solar_north[key] + mzp_angle)
         value = (1 / 3) * np.sum(
             [
-                data_i * (4 * np.cos(angle_difference_radians(phi, theta_i + reference_angle)) ** 2 - 1)
+                data_i * (4 * np.cos(_angle_difference_radians(phi, theta_i + reference_angle)) ** 2 - 1)
                 for theta_i, data_i in input_triplet.values()
             ],
             axis=0,

--- a/solpolpy/transforms.py
+++ b/solpolpy/transforms.py
@@ -197,21 +197,17 @@ def _mzp_cubes_from_stack(
 def _instrument_frame_polarizer_angles(input_collection: NDCollection) -> u.Quantity:
     """Return M/Z/P polarizer angles in the instrument frame."""
     data_shape = get_template_cube(input_collection, preferred_key="Z").data.shape
-    lats = compute_lats(input_collection["Z"].wcs, data_shape)
-
-    polarizer_difference = {
-        key: as_angle(input_collection[key].meta.get("POLAROFF", 0), u.degree) for key in ["M", "Z", "P"]
-    }
-    solar_north = {
-        key: solnorth_from_wcs(input_collection[key].wcs, shape=data_shape, precomputed_lats=lats)
-        for key in ["M", "Z", "P"]
-    }
-
     return np.stack(
         [
-            wrap_linear_polarization(solar_north["M"] + MZP_ANGLES[0] + polarizer_difference["M"]),
-            wrap_linear_polarization(solar_north["Z"] + MZP_ANGLES[1] + polarizer_difference["Z"]),
-            wrap_linear_polarization(solar_north["P"] + MZP_ANGLES[2] + polarizer_difference["P"]),
+            np.full(
+                data_shape,
+                wrap_linear_polarization(
+                    as_angle(input_collection[key].meta["POLAR"], u.degree)
+                    + as_angle(input_collection[key].meta.get("POLAROFF", 0), u.degree)
+                ).to_value(u.degree),
+            )
+            * u.degree
+            for key in ["M", "Z", "P"]
         ]
     )
 
@@ -425,6 +421,12 @@ def bp3_to_bthp(input_collection, **kwargs):
     Notes
     ------
     Equations 9, 15, 16 in DeForest et al. 2022.
+
+    Forward direction: (B, pB, pBp, alpha) -> (B, theta, p).
+
+    theta is the polarization position angle measured CCW from solar north,
+    wrapped to [-pi/2, pi/2) (linear-polarization axis convention).
+    p is the fractional degree of linear polarization in [0, 1].
     """""
     B, pB, pBp = input_collection["B"].data, input_collection["pB"].data, input_collection["pBp"].data
     alpha = _alpha_data(input_collection)
@@ -444,6 +446,45 @@ def bp3_to_bthp(input_collection, **kwargs):
         ("theta", NDCube(theta, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Theta"))),
         ("p", NDCube(p, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="Degree of Polarization"))),
     ]
+    _append_alpha(cubes, input_collection, mask=mask)
+    return _collection_from_cubes(cubes)
+
+
+@transform(System.bthp, System.bp3, use_alpha=True)
+def bthp_to_bp3(input_collection, **kwargs):
+    """
+    Notes
+    ------
+    Inverse of Equations 15 and 16 in DeForest et al. 2022.
+
+    Recovers (pB, pBp) from (theta, p, B, alpha) by reversing the
+    bp3_to_bthp mapping::
+
+        psi  = wrap_pm_pi(2 * (theta - pi/2 - alpha))
+        pB   = p * B * cos(psi)
+        pBp  = p * B * sin(psi)
+
+    The wrapping to [-pi, pi) ensures the unique pre-image under
+    wrap_linear_polarization used in the forward direction.
+    """""
+    B = input_collection["B"].data
+    theta = as_angle(input_collection["theta"].data, u.radian).to_value(u.radian)
+    p = input_collection["p"].data
+    alpha = _alpha_data(input_collection).to_value(u.radian)
+
+    psi = ((2 * (theta - np.pi / 2 - alpha)) + np.pi) % (2 * np.pi) - np.pi
+    total_pol = p * B
+    pB = total_pol * np.cos(psi)
+    pBp = total_pol * np.sin(psi)
+
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="B")
+    cubes = [
+        ("B", NDCube(B, wcs=template.wcs, mask=mask, meta=template.meta)),
+        ("pB", NDCube(pB, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="pB"))),
+        ("pBp", NDCube(pBp, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR="pB-prime"))),
+    ]
+    _append_alpha(cubes, input_collection, mask=mask)
     return _collection_from_cubes(cubes)
 
 
@@ -552,10 +593,18 @@ def fourpol_to_stokes(input_collection, **kwargs):
     ------
     Table 1 in DeForest et al. 2022.
 
+    Sign convention (IAU / consistent with ``mzpsolar_to_stokes``)::
+
+        I = B_0  + B_90
+        Q = B_0  - B_90    (positive for N-S / along-north polarization)
+        U = B_45 - B_135   (positive for NE-SW polarization)
+
+    Q < 0 for tangential (east-west) Thomson-scattered coronal light,
+    matching the sign produced by ``mzpsolar_to_stokes``.
     """""
     Bi = input_collection[str(0 * u.degree)].data + input_collection[str(90 * u.degree)].data
-    Bq = input_collection[str(90 * u.degree)].data - input_collection[str(0 * u.degree)].data
-    Bu = input_collection[str(135 * u.degree)].data - input_collection[str(45 * u.degree)].data
+    Bq = input_collection[str(0 * u.degree)].data - input_collection[str(90 * u.degree)].data
+    Bu = input_collection[str(45 * u.degree)].data - input_collection[str(135 * u.degree)].data
 
     mask = combine_all_collection_masks(input_collection)
     template = get_template_cube(input_collection, preferred_key=str(0 * u.degree))
@@ -567,13 +616,83 @@ def fourpol_to_stokes(input_collection, **kwargs):
     return _collection_from_cubes(cubes)
 
 
+@transform(System.stokes, System.fourpol, use_alpha=False)
+def stokes_to_fourpol(input_collection, **kwargs):
+    """
+    Notes
+    ------
+    Inverse of ``fourpol_to_stokes``.  Recovers four-polarizer brightness
+    values from Stokes (I, Q, U) using the IAU sign convention::
+
+        B_0   = (I + Q) / 2
+        B_45  = (I + U) / 2
+        B_90  = (I - Q) / 2
+        B_135 = (I - U) / 2
+
+    Roundtrip with ``fourpol_to_stokes`` is exact.
+    """
+    Bi = input_collection["I"].data
+    Bq = input_collection["Q"].data
+    Bu = input_collection["U"].data
+
+    B0   = (Bi + Bq) / 2
+    B45  = (Bi + Bu) / 2
+    B90  = (Bi - Bq) / 2
+    B135 = (Bi - Bu) / 2
+
+    mask = combine_all_collection_masks(input_collection)
+    template = get_template_cube(input_collection, preferred_key="I")
+    pol_0   = str(0.0   * u.degree)
+    pol_45  = str(45.0  * u.degree)
+    pol_90  = str(90.0  * u.degree)
+    pol_135 = str(135.0 * u.degree)
+    cubes = [
+        (pol_0,   NDCube(B0,   wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR=0.0   * u.degree))),
+        (pol_45,  NDCube(B45,  wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR=45.0  * u.degree))),
+        (pol_90,  NDCube(B90,  wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR=90.0  * u.degree))),
+        (pol_135, NDCube(B135, wcs=template.wcs, mask=mask, meta=clone_meta(template, POLAR=135.0 * u.degree))),
+    ]
+    return _collection_from_cubes(cubes)
+
+
 @transform(System.mzpsolar, System.mzpinstru, use_alpha=False)
 def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwargs):
-    """Notes
-        -----
-        Equation 45 in DeForest et al. 2022.
-        out_angles: list of target angles in degree
-        """
+    """Convert solar-frame MZP to instrument-frame MZP.
+
+    Notes
+    -----
+    Equation 45 in DeForest et al. 2022.
+
+    **Angle convention**
+
+    *Solar frame (mzpsolar)*
+        - ``POLAR`` stores the solar position angle of each polarizer:
+          M = −60°, Z = 0°, P = +60°, measured CCW from solar north.
+        - ``POLARREF = "Solar"`` flags that ``POLAR`` is relative to solar north.
+        - ``POLAROFF`` is an optional mechanical misalignment of the polarizer
+          wheel *within* the instrument, not yet accounted for.
+
+    *Instrument frame (mzpinstru)*
+        - ``POLAR`` stores the same nominal solar-origin angle (−60 / 0 / 60).
+        - ``POLARREF = "Instrument"`` flags that the *effective* angle in the
+          image plane is ``POLAR + POLAROFF`` (i.e. after applying the wheel
+          offset).
+        - The brightness values themselves are what the physical polarizer
+          (at instrument angle ``POLAR + POLAROFF``) would record, expressed
+          in the coordinate system of the *instrument* rather than the Sun.
+
+    **Projection step**
+        For each target polarizer *j* (at instrument angle
+        ``alpha_j = POLAR_j + POLAROFF_j``)::
+
+            phi_j = alpha_j - solar_north        # solar-frame angle of pol. j
+            B_j   = (1/3) * sum_i [B_i * (4*cos²(phi_j − theta_i) − 1)]
+
+        where ``theta_i`` are the *solar-frame* angles of the source (solar)
+        polarizers (−60°, 0°, +60°) and ``solar_north`` is the pixel-by-pixel
+        position angle of solar north in the instrument/image frame (computed
+        from the WCS gradient).
+    """
     mask = combine_all_collection_masks(input_collection)
     solar_north = _solar_north_angles(input_collection)
     cubes = []
@@ -615,10 +734,32 @@ def mzpsolar_to_mzpinstru(input_collection, reference_angle=0 * u.degree, **kwar
 
 @transform(System.mzpinstru, System.mzpsolar, use_alpha=False)
 def mzpinstru_to_mzpsolar(input_collection, reference_angle=0*u.degree, **kwargs):
-    """Notes
+    """Convert instrument-frame MZP to solar-frame MZP.
+
+    Notes
     -----
     Equation 45 in DeForest et al. 2022.
-    angles: list of input angles in degree
+
+    **Angle convention** — see :func:`mzpsolar_to_mzpinstru` for full
+    definitions of ``POLAR``, ``POLAROFF``, and ``POLARREF``.
+
+    **Projection step**
+        The *effective instrument angle* of source polarizer *i* is::
+
+            theta_i = POLAR_i + POLAROFF_i
+
+        For each target solar polarizer *k* (at solar angle ``mzp_angle_k``
+        ∈ {−60°, 0°, +60°}) the corresponding *instrument-frame* angle is::
+
+            phi_k = solar_north + mzp_angle_k
+
+        The brightness is then obtained by projecting the instrument-frame
+        measurements onto ``phi_k`` via Eq. 45::
+
+            B_k = (1/3) * sum_i [B_i * (4*cos²(phi_k − theta_i) − 1)]
+
+        ``solar_north`` is the pixel-by-pixel position angle of solar north
+        in the instrument/image frame (from the WCS gradient).
     """
     mask = combine_all_collection_masks(input_collection)
     solar_north = _solar_north_angles(input_collection)

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -243,13 +243,14 @@ def solnorth_from_wcs(input_wcs, shape, precomputed_lats=None):
     # Compute gradient of solar latitude (points toward solar north)
     dy_lat, dx_lat = np.gradient(lat)
 
-    # Normalize vectors
+    # Normalize vectors in image coordinates: +x is right, +y is down (python convention).
     norm = np.hypot(dx_lat, dy_lat)
     norm[norm == 0] = np.nan
     north_dx = dx_lat / norm
     north_dy = dy_lat / norm
 
-    # angle from +Y direction
-    angle_solar_north = np.degrees(np.arctan2(north_dy, north_dx)) - 90
+    # Convert to the package convention in a sky-style basis:
+    # +x is right, +y is up, north = 0, positive angles are counterclockwise.
+    angle_solar_north = np.degrees(np.arctan2(north_dx, -north_dy))
 
     return angle_solar_north * u.degree

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -210,10 +210,38 @@ def compute_lats(wcs, shape):
     nrows, ncols = shape
     y, x = np.mgrid[0:nrows, 0:ncols]
 
-    # Get solar coordinates (Tx, Ty) for each pixel
+    # Use helioprojective latitude, which is defined across the full image and
+    # whose local gradient gives the image-plane direction of solar north.
     coords = pixel_to_skycoord(x, y, wcs)
-    lat = coords.Ty.to_value(u.deg)  # solar Y
-    return lat
+    return coords.Ty.to_value(u.deg)
+
+
+def angle_to_sky_vectors(angle):
+    """Convert package angles to sky-plane unit vectors.
+
+    Angles follow the package convention:
+    solar north = 0 and positive angles increase counterclockwise.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        x-right and y-up components.
+    """
+    angle_rad = u.Quantity(angle).to_value(u.radian)
+    return -np.sin(angle_rad), np.cos(angle_rad)
+
+
+def angle_to_image_vectors(angle):
+    """Convert package angles to image-plane unit vectors for ``origin='upper'`` plots.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        x-right and y-down components suitable for ``imshow(..., origin='upper')``
+        together with ``quiver``.
+    """
+    vx, vy_up = angle_to_sky_vectors(angle)
+    return vx, -vy_up
 
 
 
@@ -240,10 +268,8 @@ def solnorth_from_wcs(input_wcs, shape, precomputed_lats=None):
     else:
         lat = precomputed_lats
 
-    # Compute gradient of solar latitude (points toward solar north)
+    # Compute the local direction of increasing helioprojective latitude.
     dy_lat, dx_lat = np.gradient(lat)
-
-    # Normalize vectors in image coordinates: +x is right, +y is down (python convention).
     norm = np.hypot(dx_lat, dy_lat)
     norm[norm == 0] = np.nan
     north_dx = dx_lat / norm

--- a/solpolpy/util.py
+++ b/solpolpy/util.py
@@ -251,6 +251,5 @@ def solnorth_from_wcs(input_wcs, shape, precomputed_lats=None):
 
     # Convert to the package convention in a sky-style basis:
     # +x is right, +y is up, north = 0, positive angles are counterclockwise.
-    angle_solar_north = np.degrees(np.arctan2(north_dx, -north_dy))
-
+    angle_solar_north = np.degrees(np.arctan2(-north_dx, -north_dy))
     return angle_solar_north * u.degree

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+from pathlib import Path
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+os.environ.setdefault("SUNPY_CONFIGDIR", str(Path("/tmp/solpolpy-sunpy-config")))
+
+Path(os.environ["SUNPY_CONFIGDIR"]).mkdir(parents=True, exist_ok=True)

--- a/tests/test_alpha.py
+++ b/tests/test_alpha.py
@@ -1,8 +1,9 @@
 import astropy.units as u
+import astropy.wcs
 import numpy as np
 import pytest
 
-from solpolpy.alpha import radial_north
+from solpolpy.alpha import radial_from_wcs, radial_north
 
 
 @pytest.mark.parametrize("shape", [(1000, 1000), (500, 500), (500, 100)])
@@ -12,3 +13,40 @@ def test_radial_north(shape):
     assert alpha.shape == shape
     assert np.isclose(alpha.min(), -np.pi*u.radian, atol=0.01)
     assert np.isclose(alpha.max(), np.pi*u.radian, atol=0.01)
+
+
+def test_radial_north_matches_python_image_indexing_and_ccw_sign():
+    alpha = radial_north((5, 5)).to_value(u.radian)
+
+    np.testing.assert_allclose(alpha[0, 2], 0.0, atol=1e-12)
+    np.testing.assert_allclose(alpha[2, 0], np.pi / 2, atol=1e-12)
+    np.testing.assert_allclose(alpha[2, 4], -np.pi / 2, atol=1e-12)
+    np.testing.assert_allclose(np.abs(alpha[4, 2]), np.pi, atol=1e-12)
+
+
+def test_radial_from_wcs_matches_centered_north_up_geometry():
+    wcs = astropy.wcs.WCS(naxis=2)
+    wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    wcs.wcs.cunit = "deg", "deg"
+    wcs.wcs.cdelt = 0.2, -0.2
+    wcs.wcs.crpix = 3, 3
+    wcs.wcs.crval = 0, 0
+
+    alpha = radial_from_wcs(wcs, (5, 5)).to_value(u.radian)
+
+    np.testing.assert_allclose(alpha[0, 2], 0.0, atol=5e-3)
+    np.testing.assert_allclose(alpha[2, 0], np.pi / 2, atol=5e-3)
+    np.testing.assert_allclose(alpha[2, 4], -np.pi / 2, atol=5e-3)
+
+
+def test_radial_from_wcs_handles_off_center_partial_frame():
+    wcs = astropy.wcs.WCS(naxis=2)
+    wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    wcs.wcs.cunit = "deg", "deg"
+    wcs.wcs.cdelt = 0.2, -0.2
+    wcs.wcs.crpix = 3, 3
+    wcs.wcs.crval = 1.0, 0.0
+
+    alpha = radial_from_wcs(wcs, (5, 5)).to_value(u.radian)
+
+    np.testing.assert_allclose(alpha[2, 2], -np.pi / 2, atol=5e-3)

--- a/tests/test_alpha.py
+++ b/tests/test_alpha.py
@@ -15,7 +15,7 @@ def test_radial_north(shape):
     assert np.isclose(alpha.max(), np.pi*u.radian, atol=0.01)
 
 
-def test_radial_north_matches_python_image_indexing_and_ccw_sign():
+def test_radial_north_matches_image_north_up_and_ccw_sign():
     alpha = radial_north((5, 5)).to_value(u.radian)
 
     np.testing.assert_allclose(alpha[0, 2], 0.0, atol=1e-12)
@@ -24,7 +24,7 @@ def test_radial_north_matches_python_image_indexing_and_ccw_sign():
     np.testing.assert_allclose(np.abs(alpha[4, 2]), np.pi, atol=1e-12)
 
 
-def test_radial_from_wcs_matches_centered_north_up_geometry():
+def test_radial_from_wcs_matches_wcs_radial_geometry():
     wcs = astropy.wcs.WCS(naxis=2)
     wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
     wcs.wcs.cunit = "deg", "deg"
@@ -37,6 +37,7 @@ def test_radial_from_wcs_matches_centered_north_up_geometry():
     np.testing.assert_allclose(alpha[0, 2], 0.0, atol=5e-3)
     np.testing.assert_allclose(alpha[2, 0], np.pi / 2, atol=5e-3)
     np.testing.assert_allclose(alpha[2, 4], -np.pi / 2, atol=5e-3)
+    np.testing.assert_allclose(np.abs(alpha[4, 2]), np.pi, atol=5e-3)
 
 
 def test_radial_from_wcs_handles_off_center_partial_frame():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,9 +8,18 @@ import pytest
 from astropy.io import fits
 from ndcube import NDCollection, NDCube
 
-from solpolpy.core import _determine_image_shape, add_alpha, determine_input_kind, get_transform_path, resolve
+from solpolpy.alpha import radial_north
+from solpolpy.core import (
+    _determine_image_shape,
+    add_alpha,
+    determine_input_kind,
+    get_transform_equation,
+    get_transform_path,
+    resolve,
+)
 from solpolpy.errors import UnsupportedTransformationError
 from solpolpy.transforms import System
+from solpolpy.util import solnorth_from_wcs
 from tests.fixtures import *
 
 # Solar WCS
@@ -89,9 +98,12 @@ def test_check_all_paths_resolve(request):
                     pass  # skip any time the transform shouldn't be possible
                 else:
                     print(source_system, target_system, path)
+                    kwargs = {"out_angles": [0] * u.deg}
+                    if getattr(get_transform_equation(path), "uses_in_angles", False):
+                        kwargs["in_angles"] = [0, 60, 120] * u.deg
                     result = resolve(request.getfixturevalue(f"{source_system}_ones"),
                                      target_system,
-                                     out_angles=[0] * u.deg)
+                                     **kwargs)
                     assert isinstance(result, NDCollection)
 
 
@@ -110,3 +122,117 @@ def test_mzp_to_npol_as_mzp_is_constant(mzpsolar_ones):
     assert np.allclose(result['60.0 deg'].data, mzpsolar_ones["P"].data)
     assert np.allclose(result['-60.0 deg'].data, mzpsolar_ones["M"].data)
     assert np.allclose(result['0.0 deg'].data, mzpsolar_ones["Z"].data)
+
+
+def test_add_alpha_uses_wcs_information():
+    collection = NDCollection(
+        [
+            ("B", NDCube(np.zeros((6, 6)), wcs=wcs, meta={"POLAR": "B"})),
+            ("pB", NDCube(np.zeros((6, 6)), wcs=wcs, meta={"POLAR": "pB"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    out = add_alpha(collection)
+
+    assert "alpha" in out
+    assert out["alpha"].data.shape == (6, 6)
+    assert not np.allclose(u.Quantity(out["alpha"].data, unit=u.radian).value, 0)
+
+
+def test_add_alpha_is_north_referenced_for_north_up_wcs():
+    north_up_wcs = astropy.wcs.WCS(naxis=2)
+    north_up_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    north_up_wcs.wcs.cunit = "deg", "deg"
+    north_up_wcs.wcs.cdelt = 0.2, -0.2
+    north_up_wcs.wcs.crpix = 3, 3
+    north_up_wcs.wcs.crval = 0, 0
+
+    collection = NDCollection(
+        [
+            ("B", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": "B"})),
+            ("pB", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": "pB"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    out = add_alpha(collection)
+    alpha = u.Quantity(out["alpha"].data, unit=u.radian).to_value(u.radian)
+
+    np.testing.assert_allclose(alpha[0, 2], 0.0, atol=5e-3)
+    np.testing.assert_allclose(alpha[2, 0], np.pi / 2, atol=5e-3)
+    np.testing.assert_allclose(alpha[2, 4], -np.pi / 2, atol=5e-3)
+
+
+def test_add_alpha_uses_wcs_for_off_center_partial_frame():
+    off_center_wcs = astropy.wcs.WCS(naxis=2)
+    off_center_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    off_center_wcs.wcs.cunit = "deg", "deg"
+    off_center_wcs.wcs.cdelt = 0.2, -0.2
+    off_center_wcs.wcs.crpix = 3, 3
+    off_center_wcs.wcs.crval = 1.0, 0.0
+
+    collection = NDCollection(
+        [
+            ("B", NDCube(np.zeros((5, 5)), wcs=off_center_wcs, meta={"POLAR": "B"})),
+            ("pB", NDCube(np.zeros((5, 5)), wcs=off_center_wcs, meta={"POLAR": "pB"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    out = add_alpha(collection)
+    alpha = u.Quantity(out["alpha"].data, unit=u.radian).to_value(u.radian)
+
+    np.testing.assert_allclose(alpha[2, 2], -np.pi / 2, atol=5e-3)
+    assert not np.allclose(alpha, radial_north((5, 5)).to_value(u.radian))
+
+
+def test_solnorth_from_wcs_uses_north_zero_ccw_positive():
+    north_up_wcs = astropy.wcs.WCS(naxis=2)
+    north_up_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    north_up_wcs.wcs.cunit = "deg", "deg"
+    north_up_wcs.wcs.cdelt = 0.2, -0.2
+    north_up_wcs.wcs.crpix = 3, 3
+    north_up_wcs.wcs.crval = 0, 0
+
+    north_up = solnorth_from_wcs(north_up_wcs, (5, 5)).to_value(u.deg)
+    np.testing.assert_allclose(north_up[2, 2], 0.0, atol=5e-3)
+
+    rotated_wcs = astropy.wcs.WCS(naxis=2)
+    rotated_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    rotated_wcs.wcs.cunit = "deg", "deg"
+    rotated_wcs.wcs.cdelt = 0.2, -0.2
+    rotated_wcs.wcs.crpix = 3, 3
+    rotated_wcs.wcs.crval = 0, 0
+    rotated_wcs.wcs.pc = np.array([[0, 1], [-1, 0]])
+
+    rotated = solnorth_from_wcs(rotated_wcs, (5, 5)).to_value(u.deg)
+    np.testing.assert_allclose(rotated[2, 2], 90.0, atol=5e-3)
+
+
+def test_solnorth_from_wcs_matches_latitude_gradient_direction():
+    north_up_wcs = astropy.wcs.WCS(naxis=2)
+    north_up_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    north_up_wcs.wcs.cunit = "deg", "deg"
+    north_up_wcs.wcs.cdelt = 0.2, -0.2
+    north_up_wcs.wcs.crpix = 3, 3
+    north_up_wcs.wcs.crval = 0, 0
+
+    shape = (5, 5)
+    y, x = np.mgrid[0:shape[0], 0:shape[1]]
+    angle = solnorth_from_wcs(north_up_wcs, shape).to_value(u.rad)
+
+    coords = astropy.wcs.utils.pixel_to_skycoord(x, y, north_up_wcs)
+    lat = coords.Ty.to_value(u.deg)
+    dy_lat, dx_lat = np.gradient(lat)
+    norm = np.hypot(dx_lat, dy_lat)
+    norm[norm == 0] = np.nan
+
+    vx_from_angle = np.sin(angle)
+    vy_from_angle = np.cos(angle)
+
+    np.testing.assert_allclose(vx_from_angle, dx_lat / norm, atol=1e-12, rtol=1e-12)
+    np.testing.assert_allclose(vy_from_angle, -dy_lat / norm, atol=1e-12, rtol=1e-12)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,10 +8,12 @@ import pytest
 from astropy.io import fits
 from ndcube import NDCollection, NDCube
 
+from solpolpy.constants import ASPIICS_REFERENCE_ANGLE, LASCO_REFERENCE_ANGLE, STEREOA_REFERENCE_ANGLE, STEREOB_REFERENCE_ANGLE
 from solpolpy.alpha import radial_north
 from solpolpy.core import (
     _determine_image_shape,
     add_alpha,
+    determine_reference_angle,
     determine_input_kind,
     get_transform_equation,
     get_transform_path,
@@ -164,6 +166,76 @@ def test_add_alpha_is_north_referenced_for_north_up_wcs():
     np.testing.assert_allclose(alpha[0, 2], 0.0, atol=5e-3)
     np.testing.assert_allclose(alpha[2, 0], np.pi / 2, atol=5e-3)
     np.testing.assert_allclose(alpha[2, 4], -np.pi / 2, atol=5e-3)
+    np.testing.assert_allclose(np.abs(alpha[4, 2]), np.pi, atol=5e-3)
+
+
+def test_add_alpha_flips_wcs_alpha_for_stereo_row_orientation():
+    north_up_wcs = astropy.wcs.WCS(naxis=2)
+    north_up_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    north_up_wcs.wcs.cunit = "deg", "deg"
+    north_up_wcs.wcs.cdelt = 0.2, -0.2
+    north_up_wcs.wcs.crpix = 3, 3
+    north_up_wcs.wcs.crval = 0, 0
+
+    collection = NDCollection(
+        [
+            ("0.0 deg", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": 0 * u.deg, "OBSRVTRY": "STEREO_A"})),
+            ("120.0 deg", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": 120 * u.deg, "OBSRVTRY": "STEREO_A"})),
+            ("240.0 deg", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": 240 * u.deg, "OBSRVTRY": "STEREO_A"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    out = add_alpha(collection)
+    alpha = u.Quantity(out["alpha"].data, unit=u.radian).to_value(u.radian)
+
+    np.testing.assert_allclose(alpha[4, 2], 0.0, atol=5e-3)
+    np.testing.assert_allclose(np.abs(alpha[0, 2]), np.pi, atol=5e-3)
+
+
+@pytest.mark.parametrize(
+    ("meta", "expected"),
+    [
+        ({"OBSRVTRY": "STEREO_A"}, STEREOA_REFERENCE_ANGLE),
+        ({"OBSRVTRY": "STEREO_B"}, STEREOB_REFERENCE_ANGLE),
+        ({"INSTRUME": "LASCO"}, LASCO_REFERENCE_ANGLE),
+        ({"TELESCOP": "SOHO"}, LASCO_REFERENCE_ANGLE),
+        ({}, 0 * u.degree),
+    ],
+)
+def test_determine_reference_angle_uses_instrument_constants(meta, expected):
+    collection = NDCollection(
+        [("0.0 deg", NDCube(np.zeros((2, 2)), wcs=wcs_sol, meta={"POLAR": 0 * u.deg, **meta}))],
+        meta={},
+        aligned_axes="all",
+    )
+
+    assert determine_reference_angle(collection) == expected
+
+
+def test_determine_reference_angle_uses_aspiics_wcs_x_axis_reference():
+    north_up_wcs = astropy.wcs.WCS(naxis=2)
+    north_up_wcs.wcs.ctype = "HPLN-TAN", "HPLT-TAN"
+    north_up_wcs.wcs.cunit = "deg", "deg"
+    north_up_wcs.wcs.cdelt = 0.2, -0.2
+    north_up_wcs.wcs.crpix = 3, 3
+    north_up_wcs.wcs.crval = 0, 0
+
+    collection = NDCollection(
+        [
+            ("0.0 deg", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": 0 * u.deg, "INSTRUME": "ASPIICS"})),
+            ("60.0 deg", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": 60 * u.deg, "INSTRUME": "ASPIICS"})),
+            ("120.0 deg", NDCube(np.zeros((5, 5)), wcs=north_up_wcs, meta={"POLAR": 120 * u.deg, "INSTRUME": "ASPIICS"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    reference_angle = determine_reference_angle(collection)
+
+    assert reference_angle.shape == (5, 5)
+    np.testing.assert_allclose(reference_angle[2, 2].to_value(u.deg), ASPIICS_REFERENCE_ANGLE.to_value(u.deg), atol=5e-3)
 
 
 def test_add_alpha_uses_wcs_for_off_center_partial_frame():
@@ -210,7 +282,7 @@ def test_solnorth_from_wcs_uses_north_zero_ccw_positive():
     rotated_wcs.wcs.pc = np.array([[0, 1], [-1, 0]])
 
     rotated = solnorth_from_wcs(rotated_wcs, (5, 5)).to_value(u.deg)
-    np.testing.assert_allclose(rotated[2, 2], 90.0, atol=5e-3)
+    np.testing.assert_allclose(rotated[2, 2], -90.0, atol=5e-3)
 
 
 def test_solnorth_from_wcs_matches_latitude_gradient_direction():
@@ -231,8 +303,7 @@ def test_solnorth_from_wcs_matches_latitude_gradient_direction():
     norm = np.hypot(dx_lat, dy_lat)
     norm[norm == 0] = np.nan
 
-    vx_from_angle = np.sin(angle)
+    vx_from_angle = -np.sin(angle)
     vy_from_angle = np.cos(angle)
-
     np.testing.assert_allclose(vx_from_angle, dx_lat / norm, atol=1e-12, rtol=1e-12)
     np.testing.assert_allclose(vy_from_angle, -dy_lat / norm, atol=1e-12, rtol=1e-12)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,7 +26,7 @@ from solpolpy.core import (
 )
 from solpolpy.errors import UnsupportedTransformationError
 from solpolpy.transforms import System
-from solpolpy.util import solnorth_from_wcs
+from solpolpy.util import angle_to_image_vectors, angle_to_sky_vectors, compute_lats, solnorth_from_wcs
 from tests.fixtures import *
 
 # Solar WCS
@@ -299,16 +299,21 @@ def test_solnorth_from_wcs_matches_latitude_gradient_direction():
     north_up_wcs.wcs.crval = 0, 0
 
     shape = (5, 5)
-    y, x = np.mgrid[0:shape[0], 0:shape[1]]
     angle = solnorth_from_wcs(north_up_wcs, shape).to_value(u.rad)
 
-    coords = astropy.wcs.utils.pixel_to_skycoord(x, y, north_up_wcs)
-    lat = coords.Ty.to_value(u.deg)
+    lat = compute_lats(north_up_wcs, shape)
     dy_lat, dx_lat = np.gradient(lat)
     norm = np.hypot(dx_lat, dy_lat)
     norm[norm == 0] = np.nan
 
-    vx_from_angle = -np.sin(angle)
-    vy_from_angle = np.cos(angle)
+    vx_from_angle, vy_from_angle = angle_to_sky_vectors(angle * u.radian)
     np.testing.assert_allclose(vx_from_angle, dx_lat / norm, atol=1e-12, rtol=1e-12)
     np.testing.assert_allclose(vy_from_angle, -dy_lat / norm, atol=1e-12, rtol=1e-12)
+
+
+def test_angle_to_image_vectors_match_origin_upper_plotting():
+    angle = np.array([0.0, np.pi / 2, -np.pi / 2]) * u.radian
+    vx, vy = angle_to_image_vectors(angle)
+
+    np.testing.assert_allclose(vx, np.array([0.0, -1.0, 1.0]), atol=1e-12)
+    np.testing.assert_allclose(vy, np.array([-1.0, 0.0, 0.0]), atol=1e-12)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,13 +8,18 @@ import pytest
 from astropy.io import fits
 from ndcube import NDCollection, NDCube
 
-from solpolpy.constants import ASPIICS_REFERENCE_ANGLE, LASCO_REFERENCE_ANGLE, STEREOA_REFERENCE_ANGLE, STEREOB_REFERENCE_ANGLE
 from solpolpy.alpha import radial_north
+from solpolpy.constants import (
+    ASPIICS_REFERENCE_ANGLE,
+    LASCO_REFERENCE_ANGLE,
+    STEREOA_REFERENCE_ANGLE,
+    STEREOB_REFERENCE_ANGLE,
+)
 from solpolpy.core import (
     _determine_image_shape,
     add_alpha,
-    determine_reference_angle,
     determine_input_kind,
+    determine_reference_angle,
     get_transform_equation,
     get_transform_path,
     resolve,

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -4,7 +4,7 @@ import pytest
 from ndcube import NDCollection
 
 from solpolpy.errors import TooFewFilesError
-from solpolpy.instruments import get_instrument_mask, load_data
+from solpolpy.instruments import construct_mask, get_instrument_mask, load_data
 
 
 def test_load_data():
@@ -52,3 +52,11 @@ def test_use_instrument_mask_overrides_in_load():
 
     assert out["0.0 deg"].mask.dtype == bool
     assert out["0.0 deg"].mask.shape == (2048, 2048)
+
+
+def test_construct_mask_respects_x_y_centers():
+    mask = construct_mask(inner_radius=1, outer_radius=9, center_x=3, center_y=1, shape=(4, 6))
+
+    assert mask[1, 3]  # inner radius masks the center pixel
+    assert not mask[1, 1]  # a valid annulus pixel stays unmasked
+    assert mask[0, 0]  # far edge lies outside the outer radius

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,5 +1,6 @@
 import os
 
+import astropy.units as u
 import pytest
 from ndcube import NDCollection
 
@@ -18,6 +19,7 @@ def test_load_data():
     expected_keys = ["0.0 deg", "120.0 deg", "240.0 deg"]
     assert actual_keys == expected_keys
     assert isinstance(out, NDCollection)
+    assert out["0.0 deg"].meta["POLAR"] == 0 * u.degree
 
 
 def test_load_data_fails_with_one_file():

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -9,8 +9,8 @@ from solpolpy.errors import SolpolpyError
 from solpolpy.physics import (
     MZP_ANGLES,
     as_angle,
-    bp3_from_analyzer_brightness,
-    bp3_to_analyzer_brightness,
+    bp3_from_polarizer_brightness,
+    bp3_to_polarizer_brightness,
     calculate_angle_difference,
     clone_meta,
     get_data_keys,
@@ -84,14 +84,14 @@ def test_calculate_angle_difference_wraps_quantity_inputs():
     np.testing.assert_allclose(actual.value, 20)
 
 
-def test_bp3_analyzer_brightness_roundtrip_recovers_inputs():
+def test_bp3_polarizer_brightness_roundtrip_recovers_inputs():
     B = np.array([[10.0, 12.0], [8.0, 9.0]])
     pB = np.array([[1.0, 1.5], [0.5, 0.75]])
     pBp = np.array([[0.2, -0.3], [0.1, -0.2]])
     alpha = np.full((2, 2), 15.0) * u.degree
 
-    brightness = bp3_to_analyzer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
-    recovered = bp3_from_analyzer_brightness(brightness, MZP_ANGLES, alpha)
+    brightness = bp3_to_polarizer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
+    recovered = bp3_from_polarizer_brightness(brightness, MZP_ANGLES, alpha)
 
     np.testing.assert_allclose(recovered[0], B, atol=1e-12)
     np.testing.assert_allclose(recovered[1], pB, atol=1e-12)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,8 +1,8 @@
+from types import SimpleNamespace
+
 import astropy.units as u
 import numpy as np
 import pytest
-from types import SimpleNamespace
-
 from ndcube import NDCollection, NDCube
 
 from solpolpy.errors import SolpolpyError

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,0 +1,125 @@
+import astropy.units as u
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from ndcube import NDCollection, NDCube
+
+from solpolpy.errors import SolpolpyError
+from solpolpy.physics import (
+    MZP_ANGLES,
+    as_angle,
+    bp3_from_analyzer_brightness,
+    bp3_to_analyzer_brightness,
+    calculate_angle_difference,
+    clone_meta,
+    get_data_keys,
+    get_template_cube,
+    project_three_polarizer_brightness,
+    solve_three_polarizer_brightness,
+    stack_data,
+    wrap_linear_polarization,
+    wrap_pm_pi,
+)
+from tests.fixtures import wcs
+
+
+def _collection():
+    return NDCollection(
+        [
+            ("B", NDCube(np.ones((2, 2)), wcs=wcs, meta={"POLAR": "B"})),
+            ("pB", NDCube(np.full((2, 2), 0.25), wcs=wcs, meta={"POLAR": "pB"})),
+            ("alpha", NDCube(np.zeros((2, 2)) * u.rad, wcs=wcs)),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+
+def test_collection_helpers_ignore_alpha_and_preserve_order():
+    collection = _collection()
+
+    assert get_data_keys(collection) == ["B", "pB"]
+    assert get_template_cube(collection) is collection["B"]
+    assert get_template_cube(collection, preferred_key="pB") is collection["pB"]
+    np.testing.assert_equal(stack_data(collection, ["pB", "B"])[0], collection["pB"].data)
+
+
+def test_clone_meta_deep_copies_and_updates_metadata():
+    cube = SimpleNamespace(meta={"POLAR": "B", "nested": {"value": 1}})
+
+    meta = clone_meta(cube, POLAR="pB")
+
+    assert meta["POLAR"] == "pB"
+    meta["nested"]["value"] = 2
+    assert cube.meta["nested"]["value"] == 1
+
+
+def test_as_angle_applies_default_unit_to_unitless_values():
+    actual = as_angle([0, 90], default_unit=u.degree)
+
+    assert actual.unit == u.degree
+    np.testing.assert_allclose(actual.value, [0, 90])
+
+
+def test_quantity_input_rejects_unitless_wrapped_angles():
+    with pytest.raises(TypeError):
+        wrap_pm_pi(np.pi)
+
+
+def test_angle_wrapping_preserves_input_units():
+    wrapped = wrap_pm_pi(190 * u.degree)
+    linear = wrap_linear_polarization(100 * u.degree)
+
+    assert wrapped.unit == u.degree
+    assert linear.unit == u.degree
+    np.testing.assert_allclose(wrapped.value, -170)
+    np.testing.assert_allclose(linear.value, -80)
+
+
+def test_calculate_angle_difference_wraps_quantity_inputs():
+    actual = calculate_angle_difference(10 * u.degree, 350 * u.degree)
+
+    assert actual.unit == u.degree
+    np.testing.assert_allclose(actual.value, 20)
+
+
+def test_bp3_analyzer_brightness_roundtrip_recovers_inputs():
+    B = np.array([[10.0, 12.0], [8.0, 9.0]])
+    pB = np.array([[1.0, 1.5], [0.5, 0.75]])
+    pBp = np.array([[0.2, -0.3], [0.1, -0.2]])
+    alpha = np.full((2, 2), 15.0) * u.degree
+
+    brightness = bp3_to_analyzer_brightness(B, pB, pBp, alpha, MZP_ANGLES)
+    recovered = bp3_from_analyzer_brightness(brightness, MZP_ANGLES, alpha)
+
+    np.testing.assert_allclose(recovered[0], B, atol=1e-12)
+    np.testing.assert_allclose(recovered[1], pB, atol=1e-12)
+    np.testing.assert_allclose(recovered[2], pBp, atol=1e-12)
+
+
+def test_solve_three_polarizer_brightness_supports_pixelwise_reference_angle():
+    observed_angles = np.array([-60.0, 0.0, 60.0]) * u.degree
+    solved_angles = np.array([0.0, 60.0, 120.0]) * u.degree
+    reference_angle = np.array([[0.0, 5.0], [10.0, 15.0]]) * u.degree
+    source = np.stack(
+        [
+            np.full((2, 2), 3.0),
+            np.full((2, 2), 2.0),
+            np.full((2, 2), 1.0),
+        ],
+        axis=0,
+    )
+
+    projected = project_three_polarizer_brightness(source, solved_angles, observed_angles, reference_angle)
+    recovered = solve_three_polarizer_brightness(projected, observed_angles, solved_angles, reference_angle)
+
+    np.testing.assert_allclose(recovered, source, atol=1e-12)
+
+
+def test_solve_three_polarizer_brightness_raises_for_degenerate_angles():
+    brightness = np.ones((3, 2, 2))
+    duplicate_angles = np.array([0.0, 0.0, 60.0]) * u.degree
+
+    with pytest.raises(SolpolpyError, match="degenerate"):
+        solve_three_polarizer_brightness(brightness, duplicate_angles, MZP_ANGLES)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,7 +7,8 @@ from ndcube import NDCollection, NDCube
 from pytest import fixture
 
 import solpolpy.transforms as transforms
-from solpolpy.errors import MissingAlphaError, SolpolpyError
+from solpolpy.errors import InvalidDataError, MissingAlphaError, SolpolpyError
+from solpolpy.physics.polarization import MZP_ANGLES
 from tests.fixtures import *
 
 wcs = astropy.wcs.WCS(naxis=3)
@@ -131,6 +132,11 @@ def test_stokes_mzp_ones(stokes_ones):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)
 
 
+def test_stokes_to_mzpsolar_returns_quantity_alpha_plane(stokes_ones):
+    actual = transforms.stokes_to_mzpsolar(stokes_ones)
+    np.testing.assert_allclose(actual["alpha"].data, np.full_like(actual["M"].data, np.pi / 2), rtol=1e-12, atol=1e-12)
+
+
 def test_mzp_bp3_missing_alpha_errors(mzpsolar_ones):
     with pytest.raises(MissingAlphaError):
         transforms.mzpsolar_to_bp3(mzpsolar_ones)
@@ -149,9 +155,9 @@ def bp3_ones():
 def test_bp3_mzp_ones(bp3_ones):
     actual = transforms.bp3_to_mzpsolar(bp3_ones)
     expected_data = []
-    expected_data.append(("M", NDCube(np.array([1]), wcs=wcs)))
-    expected_data.append(("Z", NDCube(np.array([-0.5]), wcs=wcs)))
-    expected_data.append(("P", NDCube(np.array([1]), wcs=wcs)))
+    expected_data.append(("M", NDCube(np.array([(3 + np.sqrt(3)) / 4]), wcs=wcs)))
+    expected_data.append(("Z", NDCube(np.array([0.0]), wcs=wcs)))
+    expected_data.append(("P", NDCube(np.array([(3 - np.sqrt(3)) / 4]), wcs=wcs)))
     expected = NDCollection(expected_data, meta={}, aligned_axes="all")
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)
@@ -181,7 +187,8 @@ def test_bp3_bthp_ones(bp3_ones):
     actual = transforms.bp3_to_bthp(bp3_ones)
     expected_data = []
     expected_data.append(("B", NDCube(np.array([1]), wcs=wcs)))
-    expected_data.append(("theta", NDCube(np.array([5 * np.pi / 8]), wcs=wcs)))
+    expected_theta = transforms.wrap_linear_polarization(5 * np.pi / 8 * u.radian).to_value(u.radian)
+    expected_data.append(("theta", NDCube(np.array([expected_theta]), wcs=wcs)))
     expected_data.append(("p", NDCube(np.array([np.sqrt(2)]), wcs=wcs)))
     expected = NDCollection(expected_data, meta={}, aligned_axes="all")
     for k in list(expected):
@@ -277,6 +284,357 @@ def test_npol_to_mzp_phi_1D():
     np.testing.assert_allclose(np.stack([actual[k].data for k in ["M", "Z", "P"]],
                                         axis=-1), expected[..., 0])
 
+
+def test_direct_transform_requires_out_angles(btbr_ones):
+    with pytest.raises(InvalidDataError, match="Out angles"):
+        transforms.btbr_to_npol(btbr_ones)
+
+
+def test_direct_transform_infers_in_angles_from_metadata(npol_ones):
+    actual = transforms.npol_to_mzpsolar(npol_ones)
+    assert list(actual.keys())[:3] == ["M", "Z", "P"]
+
+
+def test_npol_to_mzpsolar_metadata_inference_uses_solar_angles_only():
+    input_data = NDCollection(
+        [
+            ("45", NDCube(np.array([[1.0]]), wcs=wcs, meta={"POLAR": 45 * u.degree, "POLAROFF": 5 * u.degree})),
+            ("20", NDCube(np.array([[2.0]]), wcs=wcs, meta={"POLAR": 20 * u.degree, "POLAROFF": 5 * u.degree})),
+            ("55", NDCube(np.array([[3.0]]), wcs=wcs, meta={"POLAR": 55 * u.degree, "POLAROFF": 5 * u.degree})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    inferred = transforms.npol_to_mzpsolar(input_data)
+    explicit = transforms.npol_to_mzpsolar(input_data, in_angles=np.array([45.0, 20.0, 55.0]) * u.degree)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(inferred[key].data, explicit[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_npol_to_mzpsolar_ignores_polaroff_for_solar_referenced_angles():
+    input_data = NDCollection(
+        [
+            ("45", NDCube(np.array([[1.0]]), wcs=wcs, meta={"POLAR": 45 * u.degree, "POLAROFF": 90 * u.degree})),
+            ("20", NDCube(np.array([[2.0]]), wcs=wcs, meta={"POLAR": 20 * u.degree, "POLAROFF": 90 * u.degree})),
+            ("55", NDCube(np.array([[3.0]]), wcs=wcs, meta={"POLAR": 55 * u.degree, "POLAROFF": 90 * u.degree})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    inferred = transforms.npol_to_mzpsolar(input_data)
+    explicit = transforms.npol_to_mzpsolar(input_data, in_angles=np.array([45.0, 20.0, 55.0]) * u.degree)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(inferred[key].data, explicit[key].data, rtol=1e-12, atol=1e-12)
+
+
+def _roundtrip_collection(values_by_key, alpha=None):
+    cubes = []
+    for key, value in values_by_key.items():
+        cubes.append((key, NDCube(np.asarray(value, dtype=float), wcs=wcs, meta={"POLAR": key})))
+    if alpha is not None:
+        cubes.append(("alpha", NDCube(np.asarray(alpha) * u.radian, wcs=wcs, meta={"POLAR": "alpha"})))
+    return NDCollection(cubes, meta={}, aligned_axes="all")
+
+
+def test_mzpsolar_bp3_roundtrip_matches_input():
+    alpha = np.array([[0.1, 0.2], [0.3, 0.4]])
+    mzp = NDCollection(
+        [
+            ("M", NDCube(np.array([[2.0, 1.5], [1.0, 0.5]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+            ("Z", NDCube(np.array([[0.5, 1.0], [1.5, 2.0]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+            ("P", NDCube(np.array([[1.25, 0.75], [1.75, 2.25]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+            ("alpha", NDCube(alpha * u.radian, wcs=wcs)),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    bp3 = transforms.mzpsolar_to_bp3(mzp)
+    roundtrip = transforms.bp3_to_mzpsolar(bp3)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(roundtrip[key].data, mzp[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_bp3_to_mzpsolar_matches_explicit_equation():
+    B = np.array([[2.0, 3.0], [4.0, 5.0]])
+    pB = np.array([[0.3, -0.1], [0.2, -0.4]])
+    pBp = np.array([[0.5, 0.2], [-0.3, 0.1]])
+    alpha = np.array([[0.0, 0.1], [0.2, -0.1]])
+    bp3 = _roundtrip_collection({"B": B, "pB": pB, "pBp": pBp}, alpha=alpha)
+
+    actual = transforms.bp3_to_mzpsolar(bp3)
+
+    for key, angle in zip(["M", "Z", "P"], MZP_ANGLES, strict=False):
+        expected = 0.5 * (
+            B
+            - pB * np.cos(2 * (angle.to_value(u.radian) - alpha))
+            - pBp * np.sin(2 * (angle.to_value(u.radian) - alpha))
+        )
+        np.testing.assert_allclose(actual[key].data, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_mzpsolar_to_bpb_matches_equations_7_and_9():
+    alpha = np.array([[0.0, 0.1], [0.2, -0.1]])
+    mzp = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.3], [1.5, 1.7]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+            ("Z", NDCube(np.array([[0.9, 1.2], [1.4, 1.8]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+            ("P", NDCube(np.array([[1.6, 0.7], [1.1, 2.0]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+            ("alpha", NDCube(alpha * u.radian, wcs=wcs)),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    actual = transforms.mzpsolar_to_bpb(mzp)
+
+    analyzer_stack = np.stack([mzp[key].data for key in ["M", "Z", "P"]], axis=0)
+    expected_B = (2.0 / 3.0) * np.sum(analyzer_stack, axis=0)
+    expected_pB = (-4.0 / 3.0) * np.sum(
+        [
+            data * np.cos(2 * (angle.to_value(u.radian) - alpha))
+            for data, angle in zip(analyzer_stack, MZP_ANGLES, strict=False)
+        ],
+        axis=0,
+    )
+
+    np.testing.assert_allclose(actual["B"].data, expected_B, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(actual["pB"].data, expected_pB, rtol=1e-12, atol=1e-12)
+
+
+def test_btbr_to_mzpsolar_matches_equations_1_and_3():
+    alpha = np.array([[0.0, 0.1], [0.2, -0.1]])
+    Bt = np.array([[2.0, 3.0], [4.0, 5.0]])
+    Br = np.array([[1.5, 2.5], [3.5, 4.5]])
+    btbr = NDCollection(
+        [
+            ("Bt", NDCube(Bt, wcs=wcs, meta={"POLAR": "Bt"})),
+            ("Br", NDCube(Br, wcs=wcs, meta={"POLAR": "Br"})),
+            ("alpha", NDCube(alpha * u.radian, wcs=wcs)),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    actual = transforms.btbr_to_mzpsolar(btbr)
+
+    for key, angle in zip(["M", "Z", "P"], MZP_ANGLES, strict=False):
+        delta = angle.to_value(u.radian) - alpha
+        expected = Bt * np.sin(delta) ** 2 + Br * np.cos(delta) ** 2
+        np.testing.assert_allclose(actual[key].data, expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("forward", "backward", "keys", "alpha_required"),
+    [
+        (transforms.bpb_to_btbr, transforms.btbr_to_bpb, ["B", "pB"], True),
+        (transforms.bpb_to_mzpsolar, transforms.mzpsolar_to_bpb, ["B", "pB"], True),
+        (transforms.mzpsolar_to_stokes, transforms.stokes_to_mzpsolar, ["M", "Z", "P"], False),
+        (transforms.mzpsolar_to_bp3, transforms.bp3_to_mzpsolar, ["M", "Z", "P"], True),
+    ],
+)
+def test_forward_backward_roundtrip_is_systematic(forward, backward, keys, alpha_required):
+    alpha = np.array([[0.05, 0.2], [0.35, 0.5]])
+
+    if keys == ["B", "pB"]:
+        original = _roundtrip_collection(
+            {"B": np.array([[4.0, 5.0], [6.0, 7.0]]), "pB": np.array([[1.0, 0.5], [0.25, -0.2]])},
+            alpha=alpha,
+        )
+    elif keys == ["M", "Z", "P"]:
+        original = NDCollection(
+            [
+                ("M", NDCube(np.array([[1.1, 1.3], [1.5, 1.7]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+                ("Z", NDCube(np.array([[0.9, 1.2], [1.4, 1.8]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+                ("P", NDCube(np.array([[1.6, 0.7], [1.1, 2.0]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+                ("alpha", NDCube(alpha * u.radian, wcs=wcs)),
+            ]
+            if alpha_required
+            else [
+                ("M", NDCube(np.array([[1.1, 1.3], [1.5, 1.7]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+                ("Z", NDCube(np.array([[0.9, 1.2], [1.4, 1.8]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+                ("P", NDCube(np.array([[1.6, 0.7], [1.1, 2.0]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+            ],
+            meta={},
+            aligned_axes="all",
+        )
+    else:
+        raise AssertionError("Unhandled system under test")
+
+    transformed = forward(original)
+    roundtrip = backward(transformed)
+
+    for key in keys:
+        np.testing.assert_allclose(roundtrip[key].data, original[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_mzpsolar_bpb_mzpsolar_roundtrip_is_exact_when_pbp_is_zero():
+    alpha = np.array([[0.1, 0.2], [0.3, 0.4]])
+    bpb = _roundtrip_collection(
+        {"B": np.array([[4.0, 5.0], [6.0, 7.0]]), "pB": np.array([[1.0, 0.5], [0.25, -0.2]])},
+        alpha=alpha,
+    )
+
+    mzp = transforms.bpb_to_mzpsolar(bpb)
+    recovered = transforms.mzpsolar_to_bpb(mzp)
+
+    for key in ["B", "pB"]:
+        np.testing.assert_allclose(recovered[key].data, bpb[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_mzpsolar_bpb_warns_when_input_contains_nonzero_pbp():
+    alpha = np.array([[0.0, 0.1], [0.2, -0.1]])
+    bp3 = _roundtrip_collection(
+        {
+            "B": np.array([[2.0, 3.0], [4.0, 5.0]]),
+            "pB": np.array([[0.3, -0.1], [0.2, -0.4]]),
+            "pBp": np.array([[0.5, 0.2], [-0.3, 0.1]]),
+        },
+        alpha=alpha,
+    )
+    mzp = transforms.bp3_to_mzpsolar(bp3)
+
+    with pytest.warns(UserWarning, match=r"assumes pBp = 0.*max\(\|pBp/B\|\)="):
+        transforms.mzpsolar_to_bpb(mzp)
+
+
+def test_mzpsolar_btbr_mzpsolar_roundtrip_is_exact_when_pbp_is_zero():
+    alpha = np.array([[0.1, 0.2], [0.3, 0.4]])
+    bpb = _roundtrip_collection(
+        {"B": np.array([[4.0, 5.0], [6.0, 7.0]]), "pB": np.array([[1.0, 0.5], [0.25, -0.2]])},
+        alpha=alpha,
+    )
+
+    mzp = transforms.bpb_to_mzpsolar(bpb)
+    btbr = transforms.bpb_to_btbr(bpb)
+    recovered = transforms.btbr_to_mzpsolar(btbr)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(recovered[key].data, mzp[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_mzpsolar_to_btbr_warns_when_input_contains_nonzero_pbp():
+    alpha = np.array([[0.0, 0.1], [0.2, -0.1]])
+    bp3 = _roundtrip_collection(
+        {
+            "B": np.array([[2.0, 3.0], [4.0, 5.0]]),
+            "pB": np.array([[0.3, -0.1], [0.2, -0.4]]),
+            "pBp": np.array([[0.5, 0.2], [-0.3, 0.1]]),
+        },
+        alpha=alpha,
+    )
+    mzp = transforms.bp3_to_mzpsolar(bp3)
+
+    with pytest.warns(UserWarning, match=r"assumes pBp = 0.*max\(\|pBp/B\|\)="):
+        transforms.mzpsolar_to_bpb(mzp)
+
+    btbr = transforms.bpb_to_btbr(transforms.mzpsolar_to_bpb(mzp))
+    recovered = transforms.btbr_to_mzpsolar(btbr)
+
+    differences = [
+        np.nanmax(np.abs(recovered[key].data - mzp[key].data)) for key in ["M", "Z", "P"]
+    ]
+    assert max(differences) > 0
+
+
+def test_npol_mzpsolar_roundtrip_with_pixelwise_angles():
+    phi = np.stack(
+        [
+            np.array([[10.0, 20.0], [30.0, 40.0]]),
+            np.array([[35.0, 45.0], [55.0, 65.0]]),
+            np.array([[80.0, 90.0], [100.0, 110.0]]),
+        ]
+    ) * u.degree
+
+    mzp = NDCollection(
+        [
+            ("M", NDCube(np.array([[0.8, 1.2], [1.6, 2.0]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+            ("Z", NDCube(np.array([[2.1, 1.7], [1.3, 0.9]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+            ("P", NDCube(np.array([[1.4, 1.1], [0.7, 0.3]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    npol = transforms.mzpsolar_to_npol(mzp, out_angles=phi)
+    roundtrip = transforms.npol_to_mzpsolar(npol, in_angles=phi)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(roundtrip[key].data, mzp[key].data, rtol=1e-11, atol=1e-11)
+
+
+def test_mzpsolar_npol_roundtrip_ignores_polaroff_in_solar_frame():
+    phi = np.array([-60.0, 0.0, 60.0]) * u.degree
+
+    mzp = NDCollection(
+        [
+            ("M", NDCube(np.array([[0.8, 1.2], [1.6, 2.0]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLAROFF": 90 * u.degree, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.array([[2.1, 1.7], [1.3, 0.9]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLAROFF": 90 * u.degree, "POLARREF": "Solar"})),
+            ("P", NDCube(np.array([[1.4, 1.1], [0.7, 0.3]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLAROFF": 90 * u.degree, "POLARREF": "Solar"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    npol = transforms.mzpsolar_to_npol(mzp, out_angles=phi)
+    roundtrip = transforms.npol_to_mzpsolar(npol)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(roundtrip[key].data, mzp[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_reference_angle_changes_mzpsolar_to_npol():
+    input_data = NDCollection(
+        [
+            ("P", NDCube(np.array([[1.0, 2.0], [3.0, 4.0]]), wcs=wcs, meta={"POLAR": 60 * u.degree})),
+            ("Z", NDCube(np.array([[5.0, 6.0], [7.0, 8.0]]), wcs=wcs, meta={"POLAR": 0 * u.degree})),
+            ("M", NDCube(np.array([[9.0, 10.0], [11.0, 12.0]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    nominal = transforms.mzpsolar_to_npol(input_data, out_angles=np.array([0.0, 45.0, 90.0]) * u.degree)
+    shifted = transforms.mzpsolar_to_npol(
+        input_data,
+        out_angles=np.array([0.0, 45.0, 90.0]) * u.degree,
+        reference_angle=15 * u.degree,
+    )
+
+    assert any(
+        not np.allclose(nominal[key].data, shifted[key].data, rtol=1e-12, atol=1e-12)
+        for key in [str(0 * u.degree), str(45 * u.degree), str(90 * u.degree)]
+    )
+
+
+def test_reference_angle_changes_npol_to_mzpsolar():
+    input_data = NDCollection(
+        [
+            ("45", NDCube(np.array([[1.0, 2.0], [3.0, 4.0]]), wcs=wcs, meta={"POLAR": 45 * u.degree})),
+            ("20", NDCube(np.array([[5.0, 6.0], [7.0, 8.0]]), wcs=wcs, meta={"POLAR": 20 * u.degree})),
+            ("55", NDCube(np.array([[9.0, 10.0], [11.0, 12.0]]), wcs=wcs, meta={"POLAR": 55 * u.degree})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    nominal = transforms.npol_to_mzpsolar(input_data, in_angles=np.array([45.0, 20.0, 55.0]) * u.degree)
+    shifted = transforms.npol_to_mzpsolar(
+        input_data,
+        in_angles=np.array([45.0, 20.0, 55.0]) * u.degree,
+        reference_angle=15 * u.degree,
+    )
+
+    assert any(
+        not np.allclose(nominal[key].data, shifted[key].data, rtol=1e-12, atol=1e-12)
+        for key in ["M", "Z", "P"]
+    )
+
 @fixture()
 def fourpol_ones():
     wcs = astropy.wcs.WCS(naxis=1)
@@ -341,15 +699,13 @@ def mzp_ones_instru():
 
 def test_mzp_mzp_ones_instru(mzp_ones_instru):
     actual = transforms.mzpinstru_to_mzpsolar(mzp_ones_instru)
-    data, _ = np.mgrid[0:5, 0:5]
-    expected_data = [
-        ("M", NDCube(data, wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
-        ("Z", NDCube(data, wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'})),
-        ("P", NDCube(data, wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Solar'}))]
-    expected = NDCollection(expected_data, meta={}, aligned_axes="all")
-    for k in list(expected):
-        assert np.allclose(actual[str(k)].data, expected[str(k)].data, atol=1.e-5)
-        assert (actual[str(k)].meta["POLARREF"] == expected[str(k)].meta["POLARREF"])
+    outinstru = transforms.mzpsolar_to_mzpinstru(actual)
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(outinstru[key].data, mzp_ones_instru[key].data, rtol=1e-12, atol=1e-12)
+        assert actual[key].meta["POLARREF"] == "Solar"
+        assert u.Quantity(actual[key].meta["POLAROFF"]).to_value(u.degree) == 1.0
+        assert u.Quantity(outinstru[key].meta["POLAR"]).to_value(u.degree) in (-60.0, 0.0, 60.0)
+        assert u.Quantity(outinstru[key].meta["POLAROFF"]).to_value(u.degree) == 1.0
 
 @fixture()
 def mzp_ones_solar():
@@ -362,14 +718,10 @@ def mzp_ones_solar():
 
 def test_mzp_mzp_ones_solar(mzp_ones_solar):
     actual = transforms.mzpsolar_to_mzpinstru(mzp_ones_solar)
-    expected_data = [
-        ("M", NDCube(np.array([[0.99, 1.99], [1.99, 3.99]]), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'})),
-        ("Z", NDCube(np.array([[0.95, 1.91], [1.91, 3.83]]), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'})),
-        ("P", NDCube(np.array([[1.04, 2.08], [2.08, 4.16]]), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": 'Instrument'}))]
-    expected = NDCollection(expected_data, meta={}, aligned_axes="all")
-    for k in list(expected):
-        assert np.allclose(actual[str(k)].data, expected[str(k)].data, atol=1.e-2)
-        assert (actual[str(k)].meta["POLARREF"] == expected[str(k)].meta["POLARREF"])
+    recovered = transforms.mzpinstru_to_mzpsolar(actual)
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(recovered[key].data, mzp_ones_solar[key].data, rtol=1e-12, atol=1e-12)
+        assert actual[key].meta["POLARREF"] == "Instrument"
 
 def test_mzp_two_ways(mzp_ones_instru):
     outsolar = transforms.mzpinstru_to_mzpsolar(mzp_ones_instru)
@@ -377,6 +729,201 @@ def test_mzp_two_ways(mzp_ones_instru):
     assert np.allclose(outinstru["M"].data, mzp_ones_instru["M"].data, rtol=0.1)
     assert np.allclose(outinstru["Z"].data, mzp_ones_instru["Z"].data, rtol=0.1)
     assert np.allclose(outinstru["P"].data, mzp_ones_instru["P"].data, rtol=0.1)
+
+
+def test_mzpsolar_to_mzpinstru_matches_equation_45_projection():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.3], [1.5, 1.7]]), wcs=wcs_new,
+                         meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.array([[0.9, 1.2], [1.4, 1.8]]), wcs=wcs_new,
+                         meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("P", NDCube(np.array([[1.6, 0.7], [1.1, 2.0]]), wcs=wcs_new,
+                         meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    actual = transforms.mzpsolar_to_mzpinstru(solar)
+
+    shape = solar["Z"].data.shape
+    lats = transforms.compute_lats(solar["Z"].wcs, shape)
+    solar_north = {
+        key: transforms.solnorth_from_wcs(solar[key].wcs, shape=shape, precomputed_lats=lats)
+        for key in ["M", "Z", "P"]
+    }
+
+    source_stack = np.stack([solar[key].data for key in ["M", "Z", "P"]], axis=0)
+    source_angles = np.array([-60, 0, 60]) * u.degree
+    expected = {}
+    for key, nominal in zip(["M", "Z", "P"], source_angles, strict=False):
+        alpha_j = nominal + 1 * u.degree
+        phi = ((alpha_j - solar_north[key] + 90 * u.degree) % (180 * u.degree)) - 90 * u.degree
+        coeffs = [(4 * np.cos((phi - src_angle).to(u.radian).value) ** 2 - 1) / 3 for src_angle in source_angles]
+        expected[key] = sum(data * coeff for data, coeff in zip(source_stack, coeffs, strict=False))
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(actual[key].data, expected[key], rtol=1e-12, atol=1e-12)
+
+
+def test_instrument_frame_analyzer_angles_match_solar_north_convention():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("P", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    actual = transforms._instrument_frame_analyzer_angles(solar)
+    shape = solar["Z"].data.shape
+    lats = transforms.compute_lats(solar["Z"].wcs, shape)
+    expected = np.stack(
+        [
+            transforms.wrap_linear_polarization(
+                transforms.solnorth_from_wcs(solar[key].wcs, shape=shape, precomputed_lats=lats)
+                + angle
+                + 1 * u.degree
+            )
+            for key, angle in zip(["M", "Z", "P"], MZP_ANGLES, strict=False)
+        ]
+    )
+
+    np.testing.assert_allclose(actual.to_value(u.degree), expected.to_value(u.degree), rtol=1e-12, atol=1e-12)
+
+
+def test_mzpinstru_mzpsolar_equation_45_roundtrip_with_dummy_values():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.3], [1.5, 1.7]]), wcs=wcs_new,
+                         meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.array([[0.9, 1.2], [1.4, 1.8]]), wcs=wcs_new,
+                         meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("P", NDCube(np.array([[1.6, 0.7], [1.1, 2.0]]), wcs=wcs_new,
+                         meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    instru = transforms.mzpsolar_to_mzpinstru(solar)
+    recovered = transforms.mzpinstru_to_mzpsolar(instru)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(recovered[key].data, solar[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_mzpinstru_mzpsolar_roundtrip_with_nontrivial_data_and_offset():
+    instru = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.5], [0.7, 1.9]]), wcs=wcs_new,
+                         meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+            ("Z", NDCube(np.array([[0.6, 1.2], [1.8, 0.9]]), wcs=wcs_new,
+                         meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+            ("P", NDCube(np.array([[1.7, 0.8], [1.0, 2.1]]), wcs=wcs_new,
+                         meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    solar = transforms.mzpinstru_to_mzpsolar(instru)
+    recovered = transforms.mzpsolar_to_mzpinstru(solar)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(recovered[key].data, instru[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_reference_angle_changes_mzpsolar_to_mzpinstru():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.3], [1.5, 1.7]]), wcs=wcs_new,
+                         meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.array([[0.9, 1.2], [1.4, 1.8]]), wcs=wcs_new,
+                         meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("P", NDCube(np.array([[1.6, 0.7], [1.1, 2.0]]), wcs=wcs_new,
+                         meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    nominal = transforms.mzpsolar_to_mzpinstru(solar)
+    shifted = transforms.mzpsolar_to_mzpinstru(solar, reference_angle=15 * u.degree)
+
+    assert any(
+        not np.allclose(nominal[key].data, shifted[key].data, rtol=1e-12, atol=1e-12)
+        for key in ["M", "Z", "P"]
+    )
+
+
+def test_reference_angle_changes_mzpinstru_to_mzpsolar():
+    instru = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.5], [0.7, 1.9]]), wcs=wcs_new,
+                         meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+            ("Z", NDCube(np.array([[0.6, 1.2], [1.8, 0.9]]), wcs=wcs_new,
+                         meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+            ("P", NDCube(np.array([[1.7, 0.8], [1.0, 2.1]]), wcs=wcs_new,
+                         meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    nominal = transforms.mzpinstru_to_mzpsolar(instru)
+    shifted = transforms.mzpinstru_to_mzpsolar(instru, reference_angle=15 * u.degree)
+
+    assert any(
+        not np.allclose(nominal[key].data, shifted[key].data, rtol=1e-12, atol=1e-12)
+        for key in ["M", "Z", "P"]
+    )
+
+
+def test_uniform_polaroff_propagates_through_reduced_systems():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLAROFF": 7 * u.degree, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.array([[0.9]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLAROFF": 7 * u.degree, "POLARREF": "Solar"})),
+            ("P", NDCube(np.array([[1.6]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLAROFF": 7 * u.degree, "POLARREF": "Solar"})),
+            ("alpha", NDCube(np.array([[0.1]]) * u.radian, wcs=wcs)),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    for collection in [
+        transforms.mzpsolar_to_bpb(solar),
+        transforms.mzpsolar_to_bp3(solar),
+        transforms.mzpsolar_to_stokes(solar),
+        transforms.mzpsolar_to_npol(solar, out_angles=np.array([-60.0, 0.0, 60.0]) * u.degree),
+    ]:
+        for key in collection.keys():
+            if key == "alpha":
+                continue
+            assert u.Quantity(collection[key].meta["POLAROFF"]).to_value(u.degree) == 7.0
+
+
+def test_mixed_polaroff_warns_and_is_not_silently_collapsed():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1]]), wcs=wcs, meta={"POLAR": -60 * u.degree, "POLAROFF": 1 * u.degree, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.array([[0.9]]), wcs=wcs, meta={"POLAR": 0 * u.degree, "POLAROFF": 2 * u.degree, "POLARREF": "Solar"})),
+            ("P", NDCube(np.array([[1.6]]), wcs=wcs, meta={"POLAR": 60 * u.degree, "POLAROFF": 3 * u.degree, "POLARREF": "Solar"})),
+            ("alpha", NDCube(np.array([[0.1]]) * u.radian, wcs=wcs)),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    with pytest.warns(UserWarning, match="mixed POLAROFF"):
+        bpb = transforms.mzpsolar_to_bpb(solar)
+
+    for key in ["B", "pB"]:
+        assert "POLAROFF" not in bpb[key].meta
 
 
 @fixture()
@@ -388,7 +935,7 @@ def npol_degenerate():
 
 def test_npol_degenerate(npol_degenerate):
     with pytest.raises(SolpolpyError, match="Conversion matrix is degenerate"):
-        transforms.npol_to_mzpsolar(npol_degenerate, in_angles=None)
+        transforms.npol_to_mzpsolar(npol_degenerate, in_angles=[60, 60, -60] * u.degree)
 
 
 def test_mask_propagation_works_when_none_provided(fourpol_ones):
@@ -402,6 +949,34 @@ def test_mask_propagation_works_when_none_provided(fourpol_ones):
     for key in list(expected):
         assert np.allclose(actual[key].data, expected[key].data)
         assert actual[key].mask is None
+
+
+@pytest.mark.parametrize(
+    "transform_fn,input_collection",
+    [
+        (transforms.mzpsolar_to_stokes, "mzpsolar_ones"),
+        (transforms.mzpsolar_to_bpb, "mzpsolar_ones_alpha"),
+        (transforms.mzpsolar_to_bp3, "mzpsolar_ones_alpha"),
+        (transforms.bpb_to_mzpsolar, "bpb_ones"),
+        (transforms.btbr_to_mzpsolar, "btbr_ones"),
+        (transforms.btbr_to_npol, "btbr_ones"),
+        (transforms.bpb_to_btbr, "bpb_ones"),
+        (transforms.btbr_to_bpb, "btbr_ones"),
+        (transforms.stokes_to_mzpsolar, "stokes_ones"),
+        (transforms.fourpol_to_stokes, "fourpol_ones"),
+    ],
+)
+def test_reference_angle_is_inert_for_transforms_that_do_not_use_it(transform_fn, input_collection, request):
+    collection = request.getfixturevalue(input_collection)
+    kwargs = {}
+    if transform_fn is transforms.btbr_to_npol:
+        kwargs["out_angles"] = np.array([0.0, 45.0, 90.0]) * u.degree
+
+    nominal = transform_fn(collection, **kwargs)
+    shifted = transform_fn(collection, reference_angle=15 * u.degree, **kwargs)
+
+    for key in nominal.keys():
+        np.testing.assert_allclose(nominal[key].data, shifted[key].data, rtol=1e-12, atol=1e-12)
 
 
 def test_mask_propagation_works_mixed_normal_case():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -393,12 +393,12 @@ def test_mzpsolar_to_bpb_matches_equations_7_and_9():
 
     actual = transforms.mzpsolar_to_bpb(mzp)
 
-    analyzer_stack = np.stack([mzp[key].data for key in ["M", "Z", "P"]], axis=0)
-    expected_B = (2.0 / 3.0) * np.sum(analyzer_stack, axis=0)
+    polarizer_stack = np.stack([mzp[key].data for key in ["M", "Z", "P"]], axis=0)
+    expected_B = (2.0 / 3.0) * np.sum(polarizer_stack, axis=0)
     expected_pB = (-4.0 / 3.0) * np.sum(
         [
             data * np.cos(2 * (angle.to_value(u.radian) - alpha))
-            for data, angle in zip(analyzer_stack, MZP_ANGLES, strict=False)
+            for data, angle in zip(polarizer_stack, MZP_ANGLES, strict=False)
         ],
         axis=0,
     )
@@ -767,7 +767,7 @@ def test_mzpsolar_to_mzpinstru_matches_equation_45_projection():
         np.testing.assert_allclose(actual[key].data, expected[key], rtol=1e-12, atol=1e-12)
 
 
-def test_instrument_frame_analyzer_angles_match_solar_north_convention():
+def test_instrument_frame_polarizer_angles_match_solar_north_convention():
     solar = NDCollection(
         [
             ("M", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
@@ -778,7 +778,7 @@ def test_instrument_frame_analyzer_angles_match_solar_north_convention():
         aligned_axes="all",
     )
 
-    actual = transforms._instrument_frame_analyzer_angles(solar)
+    actual = transforms._instrument_frame_polarizer_angles(solar)
     shape = solar["Z"].data.shape
     lats = transforms.compute_lats(solar["Z"].wcs, shape)
     expected = np.stack(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -20,6 +20,11 @@ wcs.crval = 10, 0.5, 1
 wcs.cname = "wavelength", "HPC lat", "HPC lon"
 
 
+class _MetaValue:
+    def __init__(self, value):
+        self.value = value
+
+
 def test_bpb_mzp_zeros(bpb_zeros):
     actual = transforms.bpb_to_mzpsolar(bpb_zeros)
     expected_data = []
@@ -653,6 +658,7 @@ def fourpol_ones():
 
 
 def test_fourpol_to_stokes_ones(fourpol_ones):
+    """All-equal polarizer brightnesses -> Q=0, U=0 (sign-agnostic sanity check)."""
     actual = transforms.fourpol_to_stokes(fourpol_ones)
     expected_data = []
     expected_data.append(("I", NDCube(np.array([2]), wcs=wcs)))
@@ -661,6 +667,194 @@ def test_fourpol_to_stokes_ones(fourpol_ones):
     expected = NDCollection(expected_data, meta={}, aligned_axes="all")
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)
+
+
+def _make_fourpol(B0, B45, B90, B135, wcs_obj=None):
+    """Helper: build a fourpol NDCollection from scalar brightnesses."""
+    _wcs = wcs_obj or wcs
+    data_out = [
+        (str(0   * u.degree), NDCube(np.array([B0  ]), wcs=_wcs, meta={"POLAR": 0  })),
+        (str(45  * u.degree), NDCube(np.array([B45 ]), wcs=_wcs, meta={"POLAR": 45 })),
+        (str(90  * u.degree), NDCube(np.array([B90 ]), wcs=_wcs, meta={"POLAR": 90 })),
+        (str(135 * u.degree), NDCube(np.array([B135]), wcs=_wcs, meta={"POLAR": 135})),
+    ]
+    return NDCollection(key_data_pairs=data_out, meta={}, aligned_axes="all")
+
+
+def test_fourpol_to_stokes_sign_convention():
+    """Q = B0-B90 (positive for N-S), U = B45-B135 (positive for NE-SW).
+
+    Uses Eq. 11 with alpha=0 to generate physically motivated polarizer
+    brightnesses, then checks that fourpol_to_stokes matches mzpsolar_to_stokes.
+    """
+    alpha = 0.0          # radial direction = solar north
+    B, pB, pBp = 3.0, 1.2, 0.7
+    phi4 = np.array([0, 45, 90, 135]) * np.pi / 180
+    B4 = 0.5 * (B - pB * np.cos(2 * (phi4 - alpha)) - pBp * np.sin(2 * (phi4 - alpha)))
+    B0v, B45v, B90v, B135v = B4.tolist()
+
+    fp = _make_fourpol(B0v, B45v, B90v, B135v)
+    actual = transforms.fourpol_to_stokes(fp)
+
+    # Expected: Q = B0-B90 (IAU / mzpsolar consistent), U = B45-B135
+    assert np.isclose(actual["I"].data[0], B0v + B90v)
+    assert np.isclose(actual["Q"].data[0], B0v - B90v)
+    assert np.isclose(actual["U"].data[0], B45v - B135v)
+
+
+def test_fourpol_to_stokes_consistent_with_mzpsolar_path():
+    """Stokes (I,Q,U) from 4-pol path must match the mzpsolar_to_stokes path.
+
+    Physical state: B=3, pB=1, pBp=0.6, alpha=0.
+    Both paths should produce the same (I, Q, U) to machine precision.
+    """
+    alpha = 0.0
+    B_val, pB_val, pBp_val = 3.0, 1.0, 0.6
+
+    # 4-pol path
+    phi4 = np.array([0, 45, 90, 135]) * np.pi / 180
+    B4 = 0.5 * (B_val - pB_val * np.cos(2 * (phi4 - alpha)) - pBp_val * np.sin(2 * (phi4 - alpha)))
+    fp = _make_fourpol(*B4.tolist())
+    stokes_4pol = transforms.fourpol_to_stokes(fp)
+
+    # mzpsolar_to_stokes path
+    mzp_angles_rad = np.array([-60, 0, 60]) * np.pi / 180
+    B_mzp = 0.5 * (B_val - pB_val * np.cos(2 * (mzp_angles_rad - alpha))
+                   - pBp_val * np.sin(2 * (mzp_angles_rad - alpha)))
+    mzp_col = NDCollection(
+        [("M", NDCube(np.array([B_mzp[0]]), wcs=wcs, meta={"POLAR": -60 * u.degree})),
+         ("Z", NDCube(np.array([B_mzp[1]]), wcs=wcs, meta={"POLAR":   0 * u.degree})),
+         ("P", NDCube(np.array([B_mzp[2]]), wcs=wcs, meta={"POLAR":  60 * u.degree}))],
+        meta={}, aligned_axes="all")
+    stokes_mzp = transforms.mzpsolar_to_stokes(mzp_col)
+
+    for key in ["I", "Q", "U"]:
+        np.testing.assert_allclose(
+            stokes_4pol[key].data, stokes_mzp[key].data,
+            rtol=1e-10, atol=1e-10,
+            err_msg=f"Stokes {key}: fourpol path != mzpsolar path")
+
+
+def test_stokes_to_fourpol_roundtrip(fourpol_ones):
+    """fourpol -> stokes -> fourpol recovers original brightnesses."""
+    stokes = transforms.fourpol_to_stokes(fourpol_ones)
+    recovered = transforms.stokes_to_fourpol(stokes)
+    for key in [str(0 * u.degree), str(45 * u.degree), str(90 * u.degree), str(135 * u.degree)]:
+        np.testing.assert_allclose(
+            recovered[key].data, fourpol_ones[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_stokes_to_fourpol_specific_values():
+    """stokes_to_fourpol produces correct B0,B45,B90,B135 from known I,Q,U."""
+    I_v, Q_v, U_v = 4.0, -1.0, 0.5
+    stokes_col = NDCollection(
+        [("I", NDCube(np.array([I_v]), wcs=wcs, meta={"POLAR": "Stokes I"})),
+         ("Q", NDCube(np.array([Q_v]), wcs=wcs, meta={"POLAR": "Stokes Q"})),
+         ("U", NDCube(np.array([U_v]), wcs=wcs, meta={"POLAR": "Stokes U"}))],
+        meta={}, aligned_axes="all")
+
+    actual = transforms.stokes_to_fourpol(stokes_col)
+
+    assert np.isclose(actual[str(0.0   * u.degree)].data[0], (I_v + Q_v) / 2)
+    assert np.isclose(actual[str(45.0  * u.degree)].data[0], (I_v + U_v) / 2)
+    assert np.isclose(actual[str(90.0  * u.degree)].data[0], (I_v - Q_v) / 2)
+    assert np.isclose(actual[str(135.0 * u.degree)].data[0], (I_v - U_v) / 2)
+
+
+def test_stokes_to_fourpol_then_back_to_stokes():
+    """stokes -> fourpol -> stokes is an exact roundtrip."""
+    I_v, Q_v, U_v = 3.5, 0.8, -0.3
+    stokes_col = NDCollection(
+        [("I", NDCube(np.array([I_v]), wcs=wcs, meta={"POLAR": "Stokes I"})),
+         ("Q", NDCube(np.array([Q_v]), wcs=wcs, meta={"POLAR": "Stokes Q"})),
+         ("U", NDCube(np.array([U_v]), wcs=wcs, meta={"POLAR": "Stokes U"}))],
+        meta={}, aligned_axes="all")
+
+    fourpol = transforms.stokes_to_fourpol(stokes_col)
+    recovered = transforms.fourpol_to_stokes(fourpol)
+
+    np.testing.assert_allclose(recovered["I"].data, [I_v], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(recovered["Q"].data, [Q_v], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(recovered["U"].data, [U_v], rtol=1e-12, atol=1e-12)
+
+
+def _make_bthp(B_val, theta_val_rad, p_val, alpha_val_rad):
+    """Helper: build a bthp NDCollection from scalar values."""
+    alpha_cube = NDCube(np.array([alpha_val_rad]) * u.radian, wcs=wcs)
+    col = NDCollection(
+        [("B",     NDCube(np.array([B_val]),         wcs=wcs, meta={"POLAR": "B"})),
+         ("theta", NDCube(np.array([theta_val_rad]), wcs=wcs, meta={"POLAR": "Theta"})),
+         ("p",     NDCube(np.array([p_val]),          wcs=wcs, meta={"POLAR": "p"})),
+         ("alpha", alpha_cube)],
+        meta={}, aligned_axes="all")
+    return col
+
+
+def test_bthp_to_bp3_roundtrip():
+    """bp3 -> bthp -> bp3 is an exact roundtrip across several cases."""
+    cases = [
+        {"B": 2.0, "pB":  0.8, "pBp":  0.5, "alpha": 0.3},
+        {"B": 3.0, "pB": -0.6, "pBp":  0.9, "alpha": -0.4},
+        {"B": 1.5, "pB":  0.0, "pBp": -0.3, "alpha": 0.0},
+        {"B": 4.0, "pB":  1.2, "pBp": -1.0, "alpha": 1.1},
+    ]
+    for c in cases:
+        bp3_in = NDCollection(
+            [("B",    NDCube(np.array([c["B"]  ]), wcs=wcs, meta={"POLAR": "B"  })),
+             ("pB",   NDCube(np.array([c["pB"] ]), wcs=wcs, meta={"POLAR": "pB" })),
+             ("pBp",  NDCube(np.array([c["pBp"]]), wcs=wcs, meta={"POLAR": "pBp"})),
+             ("alpha", NDCube(np.array([c["alpha"]]) * u.radian, wcs=wcs))],
+            meta={}, aligned_axes="all")
+
+        bthp = transforms.bp3_to_bthp(bp3_in)
+        bp3_out = transforms.bthp_to_bp3(bthp)
+
+        np.testing.assert_allclose(bp3_out["B"].data,   [c["B"]  ], rtol=1e-12, atol=1e-12,
+                                   err_msg=f"B mismatch for case {c}")
+        np.testing.assert_allclose(bp3_out["pB"].data,  [c["pB"] ], rtol=1e-12, atol=1e-12,
+                                   err_msg=f"pB mismatch for case {c}")
+        np.testing.assert_allclose(bp3_out["pBp"].data, [c["pBp"]], rtol=1e-12, atol=1e-12,
+                                   err_msg=f"pBp mismatch for case {c}")
+
+
+def test_bthp_to_bp3_specific_values():
+    """bthp_to_bp3 recovers correct pB/pBp from known theta, p, alpha."""
+    B_v, pB_v, pBp_v, alpha_v = 2.0, 0.8, 0.5, 0.3
+
+    # Compute theta and p the same way bp3_to_bthp does
+    theta_v = transforms.wrap_linear_polarization(
+        0.5 * np.arctan2(pBp_v, pB_v) * u.radian + np.pi / 2 * u.radian + alpha_v * u.radian
+    ).to_value(u.radian)
+    p_v = np.sqrt(pB_v**2 + pBp_v**2) / B_v
+
+    bthp = _make_bthp(B_v, theta_v, p_v, alpha_v)
+    result = transforms.bthp_to_bp3(bthp)
+
+    np.testing.assert_allclose(result["B"].data,   [B_v  ], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result["pB"].data,  [pB_v ], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result["pBp"].data, [pBp_v], rtol=1e-12, atol=1e-12)
+
+
+def test_bthp_to_bp3_alpha_is_preserved_in_output():
+    """bthp_to_bp3 must carry the alpha cube through to the output."""
+    bthp = _make_bthp(2.0, 0.3, 0.6, 0.1)
+    result = transforms.bthp_to_bp3(bthp)
+    assert "alpha" in result
+    alpha_data = result["alpha"].data
+    # alpha may be stored as a Quantity or a plain array; handle both
+    if hasattr(alpha_data, "to_value"):
+        alpha_val = alpha_data.to_value(u.radian)
+    else:
+        alpha_val = np.asarray(alpha_data)
+    np.testing.assert_allclose(alpha_val, [0.1], rtol=1e-12, atol=1e-12)
+
+
+def test_bthp_to_bp3_zero_polarization():
+    """When p=0 the output pB and pBp are both zero regardless of theta."""
+    bthp = _make_bthp(3.0, 0.5, 0.0, 0.2)   # p = 0
+    result = transforms.bthp_to_bp3(bthp)
+    np.testing.assert_allclose(result["pB"].data,  [0.0], atol=1e-15)
+    np.testing.assert_allclose(result["pBp"].data, [0.0], atol=1e-15)
 
 # Solar WCS
 wcs_sol = astropy.wcs.WCS(naxis=2)
@@ -703,9 +897,9 @@ def test_mzp_mzp_ones_instru(mzp_ones_instru):
     for key in ["M", "Z", "P"]:
         np.testing.assert_allclose(outinstru[key].data, mzp_ones_instru[key].data, rtol=1e-12, atol=1e-12)
         assert actual[key].meta["POLARREF"] == "Solar"
-        assert u.Quantity(actual[key].meta["POLAROFF"]).to_value(u.degree) == 1.0
-        assert u.Quantity(outinstru[key].meta["POLAR"]).to_value(u.degree) in (-60.0, 0.0, 60.0)
-        assert u.Quantity(outinstru[key].meta["POLAROFF"]).to_value(u.degree) == 1.0
+        assert transforms.as_angle(actual[key].meta["POLAROFF"], u.degree).to_value(u.degree) == 1.0
+        assert transforms.as_angle(outinstru[key].meta["POLAR"], u.degree).to_value(u.degree) in (-60.0, 0.0, 60.0)
+        assert transforms.as_angle(outinstru[key].meta["POLAROFF"], u.degree).to_value(u.degree) == 1.0
 
 @fixture()
 def mzp_ones_solar():
@@ -767,32 +961,46 @@ def test_mzpsolar_to_mzpinstru_matches_equation_45_projection():
         np.testing.assert_allclose(actual[key].data, expected[key], rtol=1e-12, atol=1e-12)
 
 
-def test_instrument_frame_polarizer_angles_match_solar_north_convention():
-    solar = NDCollection(
+def test_instrument_frame_polarizer_angles_are_uniform_in_image_frame():
+    instru = NDCollection(
         [
-            ("M", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
-            ("Z", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
-            ("P", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Solar"})),
+            ("M", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+            ("Z", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
+            ("P", NDCube(np.ones((2, 2)), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLAROFF": 1, "POLARREF": "Instrument"})),
         ],
         meta={},
         aligned_axes="all",
     )
 
-    actual = transforms._instrument_frame_polarizer_angles(solar)
-    shape = solar["Z"].data.shape
-    lats = transforms.compute_lats(solar["Z"].wcs, shape)
+    actual = transforms._instrument_frame_polarizer_angles(instru)
     expected = np.stack(
         [
             transforms.wrap_linear_polarization(
-                transforms.solnorth_from_wcs(solar[key].wcs, shape=shape, precomputed_lats=lats)
-                + angle
                 + 1 * u.degree
+                + angle
             )
-            for key, angle in zip(["M", "Z", "P"], MZP_ANGLES, strict=False)
+            * np.ones((2, 2))
+            for angle in MZP_ANGLES
         ]
     )
 
     np.testing.assert_allclose(actual.to_value(u.degree), expected.to_value(u.degree), rtol=1e-12, atol=1e-12)
+
+
+def test_solar_north_angles_vary_locally_for_solar_frame():
+    solar = NDCollection(
+        [
+            ("M", NDCube(np.ones((5, 5)), wcs=wcs_new, meta={"POLAR": -60 * u.degree, "POLARREF": "Solar"})),
+            ("Z", NDCube(np.ones((5, 5)), wcs=wcs_new, meta={"POLAR": 0 * u.degree, "POLARREF": "Solar"})),
+            ("P", NDCube(np.ones((5, 5)), wcs=wcs_new, meta={"POLAR": 60 * u.degree, "POLARREF": "Solar"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    solar_north = transforms._solar_north_angles(solar)["Z"].to_value(u.deg)
+    assert np.all(np.isfinite(solar_north))
+    assert not np.allclose(solar_north, solar_north[0, 0], atol=1e-6)
 
 
 def test_mzpinstru_mzpsolar_equation_45_roundtrip_with_dummy_values():
@@ -835,6 +1043,25 @@ def test_mzpinstru_mzpsolar_roundtrip_with_nontrivial_data_and_offset():
 
     for key in ["M", "Z", "P"]:
         np.testing.assert_allclose(recovered[key].data, instru[key].data, rtol=1e-12, atol=1e-12)
+
+
+def test_mzpinstru_to_mzpsolar_accepts_metadata_objects_with_value_attribute():
+    instru = NDCollection(
+        [
+            ("M", NDCube(np.array([[1.1, 1.1], [1.1, 1.1]]), wcs=wcs_new,
+                         meta={"POLAR": _MetaValue(-60), "POLAROFF": _MetaValue(0), "POLARREF": "Instrument"})),
+            ("Z", NDCube(np.array([[0.6, 0.6], [0.6, 0.6]]), wcs=wcs_new,
+                         meta={"POLAR": _MetaValue(0), "POLAROFF": _MetaValue(0), "POLARREF": "Instrument"})),
+            ("P", NDCube(np.array([[1.7, 1.7], [1.7, 1.7]]), wcs=wcs_new,
+                         meta={"POLAR": _MetaValue(60), "POLAROFF": _MetaValue(0), "POLARREF": "Instrument"})),
+        ],
+        meta={},
+        aligned_axes="all",
+    )
+
+    solar = transforms.mzpinstru_to_mzpsolar(instru)
+
+    assert list(solar.keys())[:3] == ["M", "Z", "P"]
 
 
 def test_reference_angle_changes_mzpsolar_to_mzpinstru():
@@ -964,6 +1191,7 @@ def test_mask_propagation_works_when_none_provided(fourpol_ones):
         (transforms.btbr_to_bpb, "btbr_ones"),
         (transforms.stokes_to_mzpsolar, "stokes_ones"),
         (transforms.fourpol_to_stokes, "fourpol_ones"),
+        (transforms.stokes_to_fourpol, "stokes_ones"),
     ],
 )
 def test_reference_angle_is_inert_for_transforms_that_do_not_use_it(transform_fn, input_collection, request):
@@ -1063,3 +1291,130 @@ def test_mask_propagation_works_when_not_all_specified(fourpol_ones):
     for k in list(expected):
         assert np.allclose(actual[str(k)].data, expected[str(k)].data)
         assert actual[str(k)].mask is None
+
+
+# ---------------------------------------------------------------------------
+# mzpsolar <-> mzpinstru physical scenario tests
+# ---------------------------------------------------------------------------
+
+def _make_mzpsolar_physical(B_arr, pB_arr, alpha_rad, polaroff_deg=0, wcs_obj=None):
+    """Build a mzpsolar NDCollection from physical (B, pB) and radial angle alpha.
+
+    B_arr, pB_arr must be broadcastable numpy arrays (shape (nrows, ncols)).
+    polaroff_deg is a scalar mechanical offset applied to all three polarizers.
+    """
+    _wcs = wcs_obj or wcs
+    mzp_rad = np.array([-60, 0, 60]) * np.pi / 180
+    cubes = []
+    for key, phi in zip(["M", "Z", "P"], mzp_rad):
+        data = 0.5 * (B_arr - pB_arr * np.cos(2 * (phi - alpha_rad)))
+        cubes.append((
+            key,
+            NDCube(data, wcs=_wcs, meta={
+                "POLAR": float(np.degrees(phi)) * u.degree,
+                "POLAROFF": polaroff_deg * u.degree,
+                "POLARREF": "Solar",
+            }),
+        ))
+    return NDCollection(cubes, meta={}, aligned_axes="all")
+
+
+def test_mzpinstru_physical_scenario_camera_roll():
+    """Numerically verify mzpsolar->mzpinstru->mzpsolar with a 30-deg camera roll.
+
+    Strategy:
+    1.  Start from a known physical scene: B=3, pB=1, radial alpha=10 deg.
+    2.  Build solar-frame MZP brightnesses analytically.
+    3.  Convert to instrument frame (camera rolled 30 deg CCW, POLAROFF=5 deg).
+    4.  Verify that instrument-frame brightnesses match an *independent* direct
+        calculation using the full instrument-frame angles and alpha in that frame.
+    5.  Convert back to solar frame and verify roundtrip to 1e-10.
+
+    This test exercises the angle algebra end-to-end without relying on the
+    code's own forward/inverse being trivially consistent; step 4 provides an
+    independent cross-check.
+    """
+    # wcs_new is the combined HPLN/HPLT + RA/DEC wcs used by all mzpinstru tests.
+    # It is defined at module level and uses a 5x5 grid (see mzp_ones_instru fixture).
+    shape = (5, 5)
+    B_phys  = np.full(shape, 3.0)
+    pB_phys = np.full(shape, 1.0)
+    # radial direction in solar frame (position angle from solar north, CCW)
+    alpha_solar = 10.0 * np.pi / 180
+
+    polaroff_deg = 5.0   # mechanical polarizer wheel offset
+
+    # solar-frame MZP angles
+    mzp_solar_deg = np.array([-60, 0, 60], dtype=float)
+    mzp_solar_rad = mzp_solar_deg * np.pi / 180
+
+    # Build solar-frame MZP
+    B_solar = [0.5 * (B_phys - pB_phys * np.cos(2 * (phi - alpha_solar)))
+               for phi in mzp_solar_rad]
+
+    solar_col = NDCollection(
+        [(key, NDCube(B_solar[i], wcs=wcs_new,
+                      meta={"POLAR": float(mzp_solar_deg[i]) * u.degree,
+                            "POLAROFF": polaroff_deg * u.degree,
+                            "POLARREF": "Solar"}))
+         for i, key in enumerate(["M", "Z", "P"])],
+        meta={}, aligned_axes="all",
+    )
+
+    instru_col = transforms.mzpsolar_to_mzpinstru(solar_col)
+
+    # --- roundtrip back to solar frame (primary assertion) -----------------
+    recovered_solar = transforms.mzpinstru_to_mzpsolar(instru_col)
+    for i, key in enumerate(["M", "Z", "P"]):
+        np.testing.assert_allclose(
+            recovered_solar[key].data, B_solar[i],
+            rtol=1e-10, atol=1e-10,
+            err_msg=f"solar roundtrip failed for {key}",
+        )
+        assert recovered_solar[key].meta["POLARREF"] == "Solar"
+
+    # --- verify instrument-frame values match Eq. 11 independently ---------
+    # Compute the true solar_north per-pixel via the same helper the code uses
+    lats = transforms.compute_lats(solar_col["Z"].wcs, shape)
+    solar_north_map = {
+        key: transforms.solnorth_from_wcs(solar_col[key].wcs, shape=shape, precomputed_lats=lats)
+        for key in ["M", "Z", "P"]
+    }
+
+    mzp_instru_angles_deg = mzp_solar_deg + polaroff_deg
+    mzp_instru_angles_rad = mzp_instru_angles_deg * np.pi / 180
+
+    for i, key in enumerate(["M", "Z", "P"]):
+        # Effective solar-frame angle of this instrument polarizer
+        phi_solar = mzp_instru_angles_rad[i] - solar_north_map[key].to_value(u.radian)
+        # Independent expected brightness (Eq. 11 with pBp=0)
+        expected = 0.5 * (B_phys - pB_phys * np.cos(2 * (phi_solar - alpha_solar)))
+        np.testing.assert_allclose(
+            instru_col[key].data, expected,
+            rtol=1e-10, atol=1e-10,
+            err_msg=f"instrument-frame {key} does not match independent calculation",
+        )
+
+
+def test_mzpinstru_mzpsolar_roundtrip_zero_roll():
+    """With zero roll and zero offset, mzpsolar -> mzpinstru -> mzpsolar = identity."""
+    data_shape = (5, 5)
+    rng = np.random.default_rng(42)
+    solar_col = NDCollection(
+        [("M", NDCube(rng.uniform(0.5, 2.0, data_shape), wcs=wcs_new,
+                      meta={"POLAR": -60 * u.degree, "POLAROFF": 0 * u.degree, "POLARREF": "Solar"})),
+         ("Z", NDCube(rng.uniform(0.5, 2.0, data_shape), wcs=wcs_new,
+                      meta={"POLAR":   0 * u.degree, "POLAROFF": 0 * u.degree, "POLARREF": "Solar"})),
+         ("P", NDCube(rng.uniform(0.5, 2.0, data_shape), wcs=wcs_new,
+                      meta={"POLAR":  60 * u.degree, "POLAROFF": 0 * u.degree, "POLARREF": "Solar"}))],
+        meta={}, aligned_axes="all",
+    )
+
+    instru  = transforms.mzpsolar_to_mzpinstru(solar_col)
+    recovered = transforms.mzpinstru_to_mzpsolar(instru)
+
+    for key in ["M", "Z", "P"]:
+        np.testing.assert_allclose(
+            recovered[key].data, solar_col[key].data, rtol=1e-11, atol=1e-11,
+            err_msg=f"identity roundtrip failed for {key}")
+        assert recovered[key].meta["POLARREF"] == "Solar"


### PR DESCRIPTION
## PR summary

- Adds and refines equation-based polarization transform helpers following DeForest et al. 2022.
- Improves the implementation of the MZP/BpB/BtBr/Bp3/Stokes transform paths.
- Adds broader transform coverage.
- Updated tests for round-trip behavior, physical consistency, warning behavior, and metadata preservation.
